### PR TITLE
Refactor code in order to use structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +402,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,11 +478,11 @@ name = "rustscan"
 version = "1.2.0"
 dependencies = [
  "async-std",
- "clap",
  "colored",
  "futures",
  "rlimit",
  "shell-words",
+ "structopt",
 ]
 
 [[package]]
@@ -508,6 +543,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +596,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
@@ -544,6 +620,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme="README.md"
 
 [dependencies]
 colored = "1.9.3"
-clap = "2.33.0"
+structopt = "0.3.15"
 async-std = "1.6.2"
 futures = "0.3"
 rlimit = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,149 +3,118 @@ extern crate shell_words;
 mod scanner;
 use scanner::Scanner;
 
-use clap::{App, Arg, AppSettings};
 use colored::*;
 use std::time::Duration;
 use std::process::{exit, Command};
-use std::convert::TryInto;
 use futures::executor::block_on;
 use rlimit::Resource;
 use rlimit::{setrlimit, getrlimit};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "rustscan", setting = structopt::clap::AppSettings::TrailingVarArg)]
+/// Fast Port Scanner built in Rust.
+/// WARNING Do not use this program against sensitive infrastructure since the
+/// specified server may not be able to handle this many socket connections at once.
+struct Opts {
+    /// The IP address to scan
+    ip: String,
+
+    ///Quiet mode. Only output the ports. No Nmap. Useful for grep or outputting to a file.
+    #[structopt(short, long)]
+    quiet: bool,
+
+    /// The batch size for port scanning, it increases or slows the speed of
+    /// scanning. Depends on the open file limit of your OS.  If you do 65535
+    /// it will do every port at the same time. Although, your OS may not
+    /// support this.
+    #[structopt(short, long,  default_value = "4500")]
+    batch_size: u64,
+
+    /// The timeout in milliseconds before a port is assumed to be closed.
+    #[structopt(short, long,  default_value = "1500")]
+    timeout: u64,
+
+    /// Automatically ups the ULIMIT with the value you provided.
+    #[structopt(short, long)]
+    ulimit: Option<u64>,
+
+    /// The Nmap arguments to run.
+    /// To use the argument -A, end RustScan's args with '-- -A'.
+    /// Example: 'rustscan -T 1500 127.0.0.1 -- -A -sC'.
+    /// This command adds -Pn -vvv -p $PORTS automatically to nmap.
+    /// For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"")
+    command: Vec<String>,
+}
 
 /// Faster Nmap scanning with Rust
 fn main() {
-    let matches = App::new("RustScan")
-        .author("Bee https://github.com/brandonskerritt")
-        .about("Fast Port Scanner built in Rust\nWARNING Do not use this program against sensitive infrastructure. The specified server may not be able to handle this many socket connections at once.")
-        .version("1.2.0")
-        .setting(AppSettings::TrailingVarArg)
+    let mut opts = Opts::from_args();
 
-        // IP address is a required argument
-        .arg(Arg::with_name("ip")
-            .required(true)
-            .index(1)
-            .long("ip-address")
-            .help("The IP address to scan"))
-        .arg(Arg::with_name("b")
-            .short("b")
-            .long("batch")
-            .takes_value(true)
-            .default_value("4500")
-            .help("Increases speed of scanning. The batch size for port scanning. Depends on your open file limit of OS. If you do 65535 it will do every port at the same time. Although, your OS may not support this."))
-        .arg(Arg::with_name("T")
-            .short("T")
-            .long("timeout")
-            .takes_value(true)
-            .default_value("1500")
-            .help("The timeout before a port is assumed to be close. In MS."))
-        .arg(Arg::with_name("q")
-            .short("-q")
-            .long("quiet")
-            .takes_value(false)
-            .help("Quiet mode. Only output the ports. No Nmap. Useful for grep or outputting to a file."))
-        .arg(Arg::with_name("u")
-            .short("u")
-            .long("ulimit")
-            .help("Automatically ups the ULIMIT with the value you provided.")
-            .takes_value(true))
-        .arg(
-            Arg::with_name("command")
-                .help("The Nmap arguments to run. To use the argument -A, end RustScan's args with '-- -A'.To run EXAMPLE: 'rustscan -T 1500 127.0.0.1 -- -A -sC'. This argument auto runs nmap {your commands} -vvv -p $PORTS. For things like --script '(safe and vuln)' enclose it in quotations \"'(safe and vuln)'\"")
-                .takes_value(true)
-                .multiple(true),
-        )
-        .get_matches();
-
-
-    let ip = matches.value_of("ip").unwrap_or("None");
-    let ulimit_arg = matches.value_of("u").unwrap_or("None");
-    let quiet = if matches.is_present("q") { true } else { false };
-    let command_matches= matches.values_of("command");
-    let command_run: String = match command_matches {
-        // We use the user supplied args
-        Some(_x) => {
-            // TODO x is the same as below, use that instead
-            matches.values_of("command").unwrap().collect::<Vec<_>>().join(" ")
-        }
-        // we default
-        None    => "-A -vvv".to_string()
-
+    let user_nmap_options = if opts.command.is_empty() {
+        "-A -vvv".to_string()
+    } else {
+       opts.command.join(" ")
     };
 
-    let mut batch_size: u64 = matches
-                        .value_of("b")
-                        .unwrap_or("None")
-                        .parse::<u64>()
-                        .unwrap();
-
-    if !quiet {
-        print_opening();
+    if !opts.quiet {
+       print_opening();
     }
 
-    // checks ulimit
+    // Updates ulimit when the argument is set
+    if opts.ulimit.is_some() {
+       let limit = opts.ulimit.unwrap();
 
-    // change ulimit size
-    if !(ulimit_arg == "None") {
-        let limit = ulimit_arg.parse::<u64>().unwrap();
-        if !quiet{
-            println!("Automatically upping ulimit to {}", ulimit_arg);
-        }
-        let uresult = setrlimit(Resource::NOFILE, limit, limit);
+       if !opts.quiet {
+           println!("Automatically upping ulimit to {}", limit);
+       }
 
-        match uresult {
-            Ok(_) => {}
-            Err(_) => {println!("ERROR.  Failed to set Ulimit.")}
-        }
+       match setrlimit(Resource::NOFILE, limit, limit) {
+           Ok(_) => {},
+           Err(_) => println!("ERROR.  Failed to set Ulimit.")
+       }
     }
-
-
 
     let (x, _) = getrlimit(Resource::NOFILE).unwrap();
 
     // if maximum limit is lower than batch size
     // automatically re-adjust the batch size
-    if x < batch_size.into() {
-        if !quiet{
+    if x < opts.batch_size {
+        if !opts.quiet {
             println!("{}", "WARNING: Your file description limit is lower than selected batch size. Please considering upping this (how to is on the README). NOTE: this may be dangerous and may cause harm to sensitive servers. Automatically reducing Batch Size to match your limit, this process isn't harmful but reduces speed.".red());
-            // TODO this is a joke please fix
+        }
 
-            // if the OS supports high file limits like 8000
-            // but the user selected a batch size higher than this
-            // reduce to a lower number
-            // basically, ubuntu is 8000
-            // but i can only get it to work on < 5k in testing
-            // 5k is default, so 3000 seems safe
-            if x > 8000{
-                batch_size = 3000
-            }
-            else {
-                let ten: u64 = 100;
-                batch_size = x - ten;
-            }
+        // TODO this is a joke please fix
+
+        // if the OS supports high file limits like 8000
+        // but the user selected a batch size higher than this
+        // reduce to a lower number
+        // basically, ubuntu is 8000
+        // but i can only get it to work on < 5k in testing
+        // 5k is default, so 3000 seems safe
+        if x > 8000{
+            opts.batch_size = 3000
+        }
+        else {
+            opts.batch_size = x - 100u64;
         }
     }
     // else if the ulimit is higher than batch size
     // tell the user they can increase batch size
     // if the user set ulimit arg they probably know what they are doing so don't print this
-    else if x + 2 > batch_size.into() && (ulimit_arg == "None"){
-        if !quiet{
-            // TODO this is a joke please fix
-            let one: u64 = 1;
-            println!("Your file description limit is higher than the batch size. You can potentially increase the speed by increasing the batch size, but this may cause harm to sensitive servers. Your limit is {}, try batch size {}.", x, x - one);
+    else if x + 2 > opts.batch_size && (opts.ulimit.is_none()){
+        if !opts.quiet {
+            println!(
+                "Your file description limit is higher than the batch size. You can potentially increase the speed by increasing the batch size, but this may cause harm to sensitive servers. Your limit is {}, try batch size {}.",
+                x,
+                x - 1u64
+            );
         }
     }
     // the user has asked to automatically up the ulimit
 
-    // gets timeout
-    let duration_timeout =
-        matches
-            .value_of("T")
-            .unwrap_or("None")
-            .parse::<u64>()
-            .unwrap();
-
     // 65535 + 1 because of 0 indexing
-    let scanner = Scanner::new(ip, 1, 65536, batch_size.try_into().unwrap(), Duration::from_millis(duration_timeout), quiet);
+    let scanner = Scanner::new(&opts.ip, 1, 65536, opts.batch_size, Duration::from_millis(opts.timeout), opts.quiet);
     let scan_result = block_on(scanner.run());
 
     // prints ports and places them into nmap string
@@ -155,11 +124,14 @@ fn main() {
     if nmap_str_ports.is_empty() {
         panic!("{} Looks like I didn't find any open ports. This is usually caused by a high batch size.
         \n*I used {} threads, consider lowering to {} with {} or a comfortable number lfor your system.
-        \n Alternatively, increase the timeout if your ping is high. Rustscan -T 2000 for 2000 second timeout.", "ERROR".red(), batch_size, (batch_size / 2).to_string().green(), "'rustscan -b <batch_size> <ip address>'".green());
+        \n Alternatively, increase the timeout if your ping is high. Rustscan -T 2000 for 2000 second timeout.", "ERROR".red(),
+        opts.batch_size,
+        (opts.batch_size / 2).to_string().green(),
+        "'rustscan -b <batch_size> <ip address>'".green());
     }
 
     // Tells the user we are now switching to Nmap
-    if !quiet{
+    if !opts.quiet {
         println!(
             "{}",
             "Starting nmap.".blue(),
@@ -170,13 +142,13 @@ fn main() {
     let ports_str = nmap_str_ports.join(",");
 
     // if quiet mode is on, return ports and exit
-    if quiet{
+    if opts.quiet {
         println!("{:?}", ports_str);
         exit(1);
     }
 
-    let nmap_args = format!("{} {} {} {} {} {}", &command_run, "-Pn", "-vvv", "-p", &ports_str, ip);
-    if !quiet {
+    let nmap_args = format!("{} {} {} {} {} {}", &user_nmap_options, "-vvv", "-Pn", "-p", &ports_str, opts.ip);
+    if !opts.quiet {
         println!("The Nmap command to be run is {}", &nmap_args);
     }
     let nmap_args = shell_words::split(&nmap_args).expect("failed to parse nmap arguments");
@@ -199,8 +171,5 @@ fn print_opening() {
     | | \\ \\ |_| \\__ \\ |_ ____) | (_| (_| | | | |
     |_|  \\_\\__,_|___/\\__|_____/ \\___\\__,_|_| |_|
     Faster nmap scanning with rust.";
-    println!(
-        "{}\n",
-        s.green(),
-    );
+    println!("{}\n", s.green());
 }


### PR DESCRIPTION
This allows us to not worry about argument parsing anymore since Rust can automatically infer the parsing logic from the type of our arguments.

**Goals:**

1. Allow us to introduce new arguments in a straightforward manner
2. Not worry about argument parsing