### PR TITLE
Remove quote on quiet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
 
     // if quiet mode is on, return ports and exit
     if opts.quiet {
-        println!("{:?}", ports_str);
+        println!("{}", ports_str);
         exit(1);
     }
 


### PR DESCRIPTION
Remove quotation from print list when using quiet. 
Associated issue: https://github.com/RustScan/RustScan/issues/56