### PR TITLE
Fail early when the specified IP format is not valid

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -15,7 +15,6 @@ use std::{
 /// batch_size is how many ports at a time should be scanned
 /// Timeout is the time RustScan should wait before declaring a port closed. As datatype Duration.
 /// Quiet is whether or not RustScan should print things, or wait until the end to print only open ports.
-/// ipv6 is whether or not this scan is an ipv6 scan.
 pub struct Scanner {
     host: IpAddr,
     start: u16,
@@ -128,8 +127,8 @@ impl Scanner {
     ///     let addr = SocketAddr::new(host, port)
     ///     self.connect(addr)
     ///     // returns Result which is either Ok(stream) for port is open, or Er for port is closed.
-    ///     // Timesout after self.timeouts seconds
-    ///    
+    ///     // Timeout occurs after self.timeout seconds
+    ///
     async fn connect(&self, addr: SocketAddr) -> io::Result<TcpStream> {
         let stream =
             io::timeout(self.timeout, async move { TcpStream::connect(addr).await }).await?;


### PR DESCRIPTION
We can let `structopt` parse the supplied IP for us and fail early when that IP address is invalid. We can also let `IpAddr` let us know when an IP is an ipv4 or ipv6 without relying on the user to supply this information to us.

I've also exracted the logic around building the final `nmap` arguments to its own function in other to make future changes easy to follow.

@brandonskerritt @smackhack could any of you test these changes? :) 