### PR TITLE
Refactor ulimit and batch_size logic consider the OS architecture

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -19,7 +19,7 @@ pub struct Scanner {
     host: IpAddr,
     start: u16,
     end: u16,
-    batch_size: u64,
+    batch_size: u32,
     timeout: Duration,
     quiet: bool,
 }
@@ -29,7 +29,7 @@ impl Scanner {
         host: IpAddr,
         start: u16,
         end: u16,
-        batch_size: u64,
+        batch_size: u32,
         timeout: Duration,
         quiet: bool,
     ) -> Self {


### PR DESCRIPTION
RustScan should be able to run on systems with either 32 or 64 bits. In order to achieve that we should rely on the `rlimit` library to get the proper unsigned int type from the system.

Fixes #58 

@brandonskerritt @smackhack some testing might be warranted here. :) 