### PR TITLE
Added gh releases, windows support, added up docker service, re-enabled discord webhooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ arch:
   - amd64
   - arm64
 
-  services:
-    - docker  
+services:
+  - docker  
 
 before_install:
 - rustup component add rustfmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 os:
   - linux
   - osx
-  - windows
+  # - windows
 
 arch:
   - amd64
@@ -32,13 +32,13 @@ script:
 - cargo fmt -- --check
 
 # Add in the github release details here
-deploy:
-  provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
-  file: "FILE TO UPLOAD"
-  skip_cleanup: true
-  on:
-    tags: true
+# deploy:
+#   provider: releases
+#   api_key: "GITHUB OAUTH TOKEN"
+#   file: "FILE TO UPLOAD"
+#   skip_cleanup: true
+#   on:
+#     tags: true
 
 after_success:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ language: rust
 os:
   - linux
   - osx
+  - windows
 
 arch:
   - amd64
   - arm64
+
+  services:
+    - docker  
 
 before_install:
 - rustup component add rustfmt
@@ -27,10 +31,19 @@ script:
 - cargo test
 - cargo fmt -- --check
 
-  #after_success:
-  #- wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
-  #- chmod +x send.sh
-  #- ./send.sh success $WEBHOOK_URL
+# Add in the github release details here
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file: "FILE TO UPLOAD"
+  skip_cleanup: true
+  on:
+    tags: true
+
+after_success:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh success $WEBHOOK_URL
 after_failure:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh


### PR DESCRIPTION
Hey there,
as earlier discussed with bee we started migrating to travisci and I added the following things to the travis ci config:

GH-Releases: you just need to fill in the file you want to upload, a token to authorize it. Not sure if its secure to do so, so may leave that until we got clearance. Also only tagged commits get released to GH-Releases

Added windows support, I dont think there would be problems with that.
Added also docker service without build target since theres an active discussion about what to do.

I also re-enabled discord webhooks since I didnt saw any problems with that.
