### PR TITLE
GH-Releases, Deb's, Caching, Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: rust
 os:
   - linux
   - osx
-  # - windows
 
 arch:
   - amd64
@@ -12,6 +11,9 @@ arch:
 services:
   - docker  
 
+# Save up the cargo build cache
+cache: cargo  
+
 before_install:
 - rustup component add rustfmt
 
@@ -19,26 +21,24 @@ before_install:
 rust:
   - stable
   - beta
-  - nightly
 jobs:
-  allow_failures:
-    - rust: nightly
   fast_finish: true
 
-# Cargo fmt
-script:
-- cargo build
-- cargo test
-- cargo fmt -- --check
+# Build Test Fmt
+script: ./scripts/build.sh
+
+# Running deb build scripts
+script: ./rustscan-debbuilder/run.sh
 
 # Add in the github release details here
-# deploy:
-#   provider: releases
-#   api_key: "GITHUB OAUTH TOKEN"
-#   file: "FILE TO UPLOAD"
-#   skip_cleanup: true
-#   on:
-#     tags: true
+deploy:
+  provider: releases
+  api_key: $GH_0AUTH_TOKEN
+  file: target/debug/rustscan
+  file: debs/*.deb
+  skip_cleanup: true
+  on:
+    tags: true
 
 after_success:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/rustscan-debbuilder/run.sh
+++ b/rustscan-debbuilder/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker build -t rustscan-builder . || exit
+docker build -t rustscan-builder ./rustscan-debbuilder || exit
 
 # This creates a volume which binds your currentdirectory/debs to 
 # the location where the deb files get spat out in the container.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+# Build Script
+cargo build
+cargo test
+cargo fmt -- --check


### PR DESCRIPTION
Fixed the problem with gh-release key getting leaked by replacing it with an env var ( $GH_0AUTH_TOKEN )
Removed windows build support since an OS dependency is breaking it.
Removed nightly build support since rust fmt is not available within nightly.
Added caching to decrease build time.
Experimented around with deb building and deploying, not sure if it will work, may review the change I made to the deb build script.