### PR TITLE
Add Travis configuration to publish doc to GitHub pages

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -133,6 +133,15 @@
       "contributions": [
         "content"
       ]
+    },
+    {
+      "login": "SuperSandro2000",
+      "name": "Sandro",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/7258858?v=4",
+      "profile": "https://supersandro.de/",
+      "contributions": [
+        "content"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,14 @@ after_failure:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh
   - ./send.sh failure $WEBHOOK_URL
+
+after_success: |
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    [ "${TRAVIS_BRANCH} " = master ] &&
+    [ "${TRAVIS_PULL_REQUEST}" = false ] &&
+    cargo doc &&
+    echo "<meta http-equiv=refresh content=0;url=rustscan/index.html>" > target/doc/index.html &&
+    sudo pip install ghp-import &&
+    ghp-import -n target/doc &&
+    git push -fq https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+  fi

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Please read the [contributing.md file](contributing.md)
 
 ## Contributors ✨
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -406,6 +406,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://cmnatic.co.uk"><img src="https://avatars3.githubusercontent.com/u/4163116?v=4" width="100px;" alt=""/><br /><sub><b>Ben (CMNatic)</b></sub></a><br /><a href="https://github.com/RustScan/RustScan/commits?author=cmnatic" title="Code">💻</a> <a href="https://github.com/RustScan/RustScan/commits?author=cmnatic" title="Documentation">📖</a> <a href="#design-cmnatic" title="Design">🎨</a></td>
     <td align="center"><a href="https://github.com/Ferryistaken"><img src="https://avatars3.githubusercontent.com/u/47927670?v=4" width="100px;" alt=""/><br /><sub><b>Alessandro Ferrari</b></sub></a><br /><a href="#content-Ferryistaken" title="Content">🖋</a></td>
     <td align="center"><a href="https://github.com/Phenomite"><img src="https://avatars2.githubusercontent.com/u/8285537?v=4" width="100px;" alt=""/><br /><sub><b>Phenomite</b></sub></a><br /><a href="#content-Phenomite" title="Content">🖋</a></td>
+    <td align="center"><a href="https://supersandro.de/"><img src="https://avatars2.githubusercontent.com/u/7258858?v=4" width="100px;" alt=""/><br /><sub><b>Sandro</b></sub></a><br /><a href="#content-SuperSandro2000" title="Content">🖋</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ RustScans **only** job is to reduce the friction between finding open ports and 
 
 | Installation Guide | Documentation | Discord |
 | ------------------ | ------------- | ------- |
-| 📖 [Installation Guide](https://github.com/RustScan/RustScan#-full-installation-guide) | 📚 [Documentation](https://github.com/RustScan/RustScan/issues/89) | 🦜 [Discord](https://discord.gg/GFrQsGy)
+| 📖 [Installation Guide](https://github.com/RustScan/RustScan#-full-installation-guide) | 📚 [Documentation](https://rustscan.github.io/RustScan/) | 🦜 [Discord](https://discord.gg/GFrQsGy)
 
 ## 🙋 Table of Contents
 * 📖 [Installation Guide](https://github.com/RustScan/RustScan#-full-installation-guide)


### PR DESCRIPTION
Closes #89

Hi!

I had a look at the link you shared the other day (which rendered poorly on my end too) and found the original source for the snippet.

It seems possible to get it running without too much hassle. My pull request adds the `after_success` phase to `.travis.yml` and I believe [the proper URL](http://rustscan.github.io/RustScan) for the GitHub pages documentation to the `README.md`.

You will need to [generate a token](https://github.com/settings/tokens) with a `public_repo` scope.

Then store and encrypt the token [in an environment variable](https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables) called `GITHUB_TOKEN` with the command below.

```sh
travis encrypt GITHUB_TOKEN=<THE_TOKEN> --add env.global
```

This should have added the proper variable to `.travis.yml` and after committing to this pull request the environment variable should now get populated and the `cargo doc` will get triggered on `master`.

Let me know if there are any issues!