### PR TITLE
Add --port and --range options

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,12 @@ rustscan -h
 ```
 
 ```
-rustscan 1.7.1
 Fast Port Scanner built in Rust. WARNING Do not use this program against sensitive infrastructure since the specified
 server may not be able to handle this many socket connections at once. - Discord https://discord.gg/GFrQsGy - GitHub
 https://github.com/RustScan/RustScan
 
 USAGE:
-    rustscan [FLAGS] [OPTIONS] <ips>... [-- <command>...]
+    rustscan [FLAGS] [OPTIONS] <ips-or-hosts>... [-- <command>...]
 
 FLAGS:
     -a, --accessible
@@ -231,6 +230,9 @@ OPTIONS:
     -b, --batch-size <batch-size>    The batch size for port scanning, it increases or slows the speed of scanning.
                                      Depends on the open file limit of your OS.  If you do 65535 it will do every port
                                      at the same time. Although, your OS may not support this [default: 4500]
+    -p, --ports <ports>...           A list of comma separed ports to be scanned. Example: 80,443,8080. These ports will
+                                     be scanned sequentially
+    -r, --range <range>              A range of ports with format start-end. Example: 1-1000
         --scan-order <scan-order>    The order of scanning to be performed. The "serial" option will scan ports in
                                      ascending order while the "random" option will scan ports randomly [default:
                                      serial]  [possible values: Serial, Random]
@@ -238,11 +240,11 @@ OPTIONS:
     -u, --ulimit <ulimit>            Automatically ups the ULIMIT with the value you provided
 
 ARGS:
-    <ips>...        A list of comma separated IP addresses to be scanned
-    <command>...    The Nmap arguments to run. To use the argument -A, end RustScan's args with '-- -A'. Example:
-                    'rustscan -T 1500 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS automatically to
-                    nmap. For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and
-                    vuln)'\"")
+    <ips-or-hosts>...    A list of comma separated IP addresses or hosts to be scanned
+    <command>...         The Nmap arguments to run. To use the argument -A, end RustScan's args with '-- -A'.
+                         Example: 'rustscan -T 1500 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS
+                         automatically to nmap. For things like --script '(safe and vuln)' enclose it in quotations
+                         marks \"'(safe and vuln)'\"")
 ```
 
 The format is `rustscan -b 500 -T 1500 192.168.0.1` to scan 192.168.0.1 with 500 batch size with a timeout of 1500ms. The timeout is how long RustScan waits for a response until it assumes the port is closed.

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -139,7 +139,7 @@ impl Scanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ScanOrder;
+    use crate::{PortRange, ScanOrder};
     use async_std::task::block_on;
     use std::{net::IpAddr, time::Duration};
 
@@ -147,7 +147,11 @@ mod tests {
     fn scanner_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
-        let strategy = PortStrategy::pick(1, 1_000, ScanOrder::Random);
+        let range = PortRange {
+            start: 1,
+            end: 1_000,
+        };
+        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(&addrs, 10, Duration::from_millis(100), true, strategy);
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -157,7 +161,11 @@ mod tests {
     fn ipv6_scanner_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["::1".parse::<IpAddr>().unwrap()];
-        let strategy = PortStrategy::pick(1, 1_000, ScanOrder::Random);
+        let range = PortRange {
+            start: 1,
+            end: 1_000,
+        };
+        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(&addrs, 10, Duration::from_millis(100), true, strategy);
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -166,7 +174,11 @@ mod tests {
     #[test]
     fn quad_zero_scanner_runs() {
         let addrs = vec!["0.0.0.0".parse::<IpAddr>().unwrap()];
-        let strategy = PortStrategy::pick(1, 1_000, ScanOrder::Random);
+        let range = PortRange {
+            start: 1,
+            end: 1_000,
+        };
+        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(&addrs, 10, Duration::from_millis(100), true, strategy);
         block_on(scanner.run());
         assert_eq!(1, 1);
@@ -174,7 +186,11 @@ mod tests {
     #[test]
     fn google_dns_runs() {
         let addrs = vec!["8.8.8.8".parse::<IpAddr>().unwrap()];
-        let strategy = PortStrategy::pick(400, 445, ScanOrder::Random);
+        let range = PortRange {
+            start: 400,
+            end: 445,
+        };
+        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(&addrs, 10, Duration::from_millis(100), true, strategy);
         block_on(scanner.run());
         assert_eq!(1, 1);
@@ -185,7 +201,11 @@ mod tests {
         let addrs = vec!["8.8.8.8".parse::<IpAddr>().unwrap()];
 
         // mac should have this automatically scaled down
-        let strategy = PortStrategy::pick(400, 600, ScanOrder::Random);
+        let range = PortRange {
+            start: 400,
+            end: 600,
+        };
+        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(&addrs, 10, Duration::from_millis(100), true, strategy);
         block_on(scanner.run());
         assert_eq!(1, 1);


### PR DESCRIPTION
These options are mutually exclusive, this means that when a user selects manual ports we will ignore ranges and vice-versa.

Manually specifying ports won't allow scan randomization for now.

⚠️ See the updated README file for more information. ⚠️ 