### PR TITLE
Reduce binary size from 2.4MB to 1.9MB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ exclude = [
     "rustscan-debbuilder/*",
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 colored = "2.0.0"
 structopt = "0.3.16"
@@ -36,3 +34,7 @@ ansi_term = "0.12.1"
 [package.metadata.deb]
 depends = "$auto, nmap"
 section = "rust"
+
+[profile.release]
+lto = true
+panic = 'abort'


### PR DESCRIPTION
By default, Cargo instructs compilation units to be compiled and optimized in isolation. LTO instructs the linker to optimize at the link stage. This can, for example, remove dead code and often times reduces binary size.

By default, when Rust code encounters a situation when it must call panic!(), it unwinds the stack and produces a helpful backtrace. The unwinding code, however, does require extra binary size. rustc can be instructed to abort immediately rather than unwind, which removes the need for this extra unwinding code.

For more information see: https://github.com/johnthagen/min-sized-rust