### PR TITLE
Fixed small typo in a warning message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ fn infer_batch_size(opts: &Opts, ulimit: rlimit::rlim) -> u16 {
 
     // Adjust the batch size when the ulimit value is lower than the desired batch size
     if ulimit < batch_size {
-        warning!("File limit is lower than default batch size. Consider upping with --ulimt. May cause harm to sensitive servers",
+        warning!("File limit is lower than default batch size. Consider upping with --ulimit. May cause harm to sensitive servers",
             opts.quiet
         );
 


### PR DESCRIPTION
There is a small typo in the file limit warning message, the correct flag is `--ulimit` but the warning message prints out `--ulimt`, nothing much just thought that you guys had more important things to do so I fixed it myself.