### PR TITLE
Allow compilation on windows (#171)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -352,7 +352,7 @@ fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {
             if !(cfg!(windows)) {
                 warning!("Your file limit is very small, which negatively impacts RustScan's speed. Use the Docker image, or up the Ulimit with '--ulimit 5000'. ");
             } else {
-                warning!("Windows is known to be much slower than scanning on Unix systems. Use the Docker image if you need faster speeds.")
+                warning!("Windows is known to be much slower than scanning on Unix systems. Use the Docker image if you need faster speeds.");
             }
             info!("Halving batch_size because ulimit is smaller than average batch size");
             batch_size = ulimit / 2

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,8 @@ fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {
             // decrease batch size to half of ulimit
             if !(cfg!(windows)) {
                 warning!("Your file limit is very small, which negatively impacts RustScan's speed. Use the Docker image, or up the Ulimit with '--ulimit 5000'. ");
+            } else {
+                warning!("Windows is known to be much slower than scanning on Unix systems. Use the Docker image if you need faster speeds.")
             }
             info!("Halving batch_size because ulimit is smaller than average batch size");
             batch_size = ulimit / 2

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,11 @@ use futures::executor::block_on;
 use rlimit::{getrlimit, setrlimit, Resource};
 
 use std::collections::HashMap;
+#[cfg(not(target_os = "windows"))]
+use std::convert::TryInto;
 use std::process::Command;
 use std::str::FromStr;
-use std::{convert::TryInto, net::IpAddr, net::ToSocketAddrs, time::Duration};
+use std::{net::IpAddr, net::ToSocketAddrs, time::Duration};
 use structopt::{clap::arg_enum, StructOpt};
 
 extern crate colorful;
@@ -158,13 +160,7 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Rlimit does not support Windows
-    // set to 1000 if Windows is used
-    let ulimit: u32 = if !(cfg!(windows)) {
-        adjust_ulimit_size(&opts)
-    } else {
-        1000
-    };
+    let ulimit: u32 = adjust_ulimit_size(&opts);
 
     let batch_size: u16 = infer_batch_size(&opts, ulimit);
 
@@ -309,6 +305,7 @@ fn parse_ips(opts: &Opts) -> Vec<IpAddr> {
     ips
 }
 
+#[cfg(not(target_os = "windows"))]
 fn adjust_ulimit_size(opts: &Opts) -> u32 {
     if opts.ulimit.is_some() {
         let limit: rlimit::rlim = opts.ulimit.unwrap().into();
@@ -329,11 +326,18 @@ fn adjust_ulimit_size(opts: &Opts) -> u32 {
     rlim.try_into().unwrap()
 }
 
+// Rlimit does not support Windows
+// set to 1000 if Windows is used
+#[cfg(target_os = "windows")]
+fn adjust_ulimit_size(_opts: &Opts) -> u32 {
+    1000
+}
+
 fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {
     let mut batch_size: u32 = opts.batch_size.into();
 
     // Adjust the batch size when the ulimit value is lower than the desired batch size
-    if ulimit < batch_size {
+    if ulimit < batch_size && !(cfg!(windows)) {
         warning!("File limit is lower than default batch size. Consider upping with --ulimt. May cause harm to sensitive servers",
             opts.quiet
         );
@@ -345,7 +349,9 @@ fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {
             // ulimit is smaller than aveage batch size
             // user must have very small ulimit
             // decrease batch size to half of ulimit
-            warning!("Your file limit is very small, which negatively impacts RustScan's speed. Use the Docker image, or up the Ulimit with '--ulimit 5000'. ");
+            if !(cfg!(windows)) {
+                warning!("Your file limit is very small, which negatively impacts RustScan's speed. Use the Docker image, or up the Ulimit with '--ulimit 5000'. ");
+            }
             info!("Halving batch_size because ulimit is smaller than average batch size");
             batch_size = ulimit / 2
         } else if ulimit > DEFAULT_FILE_DESCRIPTORS_LIMIT {

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,7 @@ fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {
 mod tests {
     use crate::{adjust_ulimit_size, infer_batch_size, parse_ips, print_opening, Opts, ScanOrder};
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn batch_size_lowered() {
         let opts = Opts {
@@ -398,6 +399,7 @@ mod tests {
         assert!(batch_size < 50_000);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn batch_size_lowered_average_size() {
         let opts = Opts {
@@ -416,6 +418,7 @@ mod tests {
 
         assert!(batch_size == 3_000);
     }
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn batch_size_equals_ulimit_lowered() {
         // because ulimit and batch size are same size, batch size is lowered
@@ -436,6 +439,7 @@ mod tests {
 
         assert!(batch_size == 4_900);
     }
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn batch_size_adjusted_2000() {
         // ulimit == batch_size

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,18 +305,8 @@ fn parse_ips(opts: &Opts) -> Vec<IpAddr> {
     ips
 }
 
-fn adjust_ulimit_size(opts: &Opts) -> u32 {
-    if !(cfg!(windows)) {
-        adjust_ulimit_size_unix(opts)
-    } else {
-        // Rlimit does not support Windows
-        // set to 1000 if Windows is used
-        1000
-    }
-}
-
 #[cfg(not(target_os = "windows"))]
-fn adjust_ulimit_size_unix(opts: &Opts) -> u32 {
+fn adjust_ulimit_size(opts: &Opts) -> u32 {
     if opts.ulimit.is_some() {
         let limit: rlimit::rlim = opts.ulimit.unwrap().into();
 
@@ -334,6 +324,13 @@ fn adjust_ulimit_size_unix(opts: &Opts) -> u32 {
     let (rlim, _) = getrlimit(Resource::NOFILE).unwrap();
 
     rlim.try_into().unwrap()
+}
+
+// Rlimit does not support Windows
+// set to 1000 if Windows is used
+#[cfg(target_os = "windows")]
+fn adjust_ulimit_size(_opts: &Opts) -> u32 {
+    1000
 }
 
 fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,8 +305,18 @@ fn parse_ips(opts: &Opts) -> Vec<IpAddr> {
     ips
 }
 
-#[cfg(not(target_os = "windows"))]
 fn adjust_ulimit_size(opts: &Opts) -> u32 {
+    if !(cfg!(windows)) {
+        adjust_ulimit_size_unix(opts)
+    } else {
+        // Rlimit does not support Windows
+        // set to 1000 if Windows is used
+        1000
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn adjust_ulimit_size_unix(opts: &Opts) -> u32 {
     if opts.ulimit.is_some() {
         let limit: rlimit::rlim = opts.ulimit.unwrap().into();
 
@@ -324,13 +334,6 @@ fn adjust_ulimit_size(opts: &Opts) -> u32 {
     let (rlim, _) = getrlimit(Resource::NOFILE).unwrap();
 
     rlim.try_into().unwrap()
-}
-
-// Rlimit does not support Windows
-// set to 1000 if Windows is used
-#[cfg(target_os = "windows")]
-fn adjust_ulimit_size(_opts: &Opts) -> u32 {
-    1000
 }
 
 fn infer_batch_size(opts: &Opts, ulimit: u32) -> u16 {


### PR DESCRIPTION
Along with @brandonskerritt's work, fixes #171 

* Conditionally import `std::convert::TryInto;`
* Define a windows-specific `adjust_ulimit_size` that just returns 1000
* Don't tell users that their ulimit is low 😅 