### PR TITLE
README.md tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Once done, you will no longer need to re-download the image (except when RustSca
 You will have to run this command every time, so we suggest aliasing it to something memorable.
 
 ```
-alias rustscan='docker run -it --rm --name rustscan rustscan/rustscan:alpine <rustscan arguments here> <ip address to scan>'
+alias rustscan='docker run -it --rm --name rustscan rustscan/rustscan:alpine'
 ```
 
 Then we can:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We strongly recommend using the `alpine` tag, as this is the latest major - stab
 
 Simply run this command against the IP you want to target:
 
-```
+```bash
 docker run -it --rm --name rustscan rustscan/rustscan:alpine <rustscan arguments here> <ip address to scan>
 ```
 
@@ -146,30 +146,30 @@ Once done, you will no longer need to re-download the image (except when RustSca
 
 You will have to run this command every time, so we suggest aliasing it to something memorable.
 
-```
+```bash
 alias rustscan='docker run -it --rm --name rustscan rustscan/rustscan:alpine'
 ```
 
 Then we can:
 
-```
+```bash
 rustscan 127.0.0.1 -t 500 -b 1500 -- -A
 ```
 
 #### To build your own image:
 
 Download the repo:
-```
+```bash
 git clone https://github.com/RustScan/RustScan.git
 ```
 
 Ensure you navigate to the download location of the repo:
-```
+```bash
 cd /path/to/download/RustScan
 ```
 
 Build away!
-```
+```bash
 docker build -t <yourimagename> .
 ```
 
@@ -179,13 +179,13 @@ docker build -t <yourimagename> .
 
 Tap the brew:
 
-```
+```bash
 brew tap brandonskerritt/rustscan
 ```
 
 Install it:
 
-```
+```bash
 brew install rustscan
 ```
 
@@ -208,11 +208,11 @@ If you maintain a community distribution and want it listed here, leave an issue
 
 # 🤸 Usage
 
-```
+```bash
 rustscan -h
 ```
 
-```
+```console
 Fast Port Scanner built in Rust. WARNING Do not use this program against sensitive infrastructure since the specified
 server may not be able to handle this many socket connections at once. - Discord https://discord.gg/GFrQsGy - GitHub
 https://github.com/RustScan/RustScan
@@ -287,7 +287,7 @@ Decreasing batch size slows down the program, so as long as it isn't too drastic
 
 Run these 3 commands:
 
-```
+```bash
 ulimit -a
 ulimit -Hn
 ulimit -Sn
@@ -301,7 +301,7 @@ Increasing the open file limit increases speed, but poses danger. Although, **op
 
 To open more, set the ulimit to a higher number:
 
-```
+```bash
 ulimit -n 5000
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,11 +208,9 @@ If you maintain a community distribution and want it listed here, leave an issue
 
 # 🤸 Usage
 
-```bash
-rustscan -h
-```
-
 ```console
+$ rustscan -h
+
 Fast Port Scanner built in Rust. WARNING Do not use this program against sensitive infrastructure since the specified
 server may not be able to handle this many socket connections at once. - Discord https://discord.gg/GFrQsGy - GitHub
 https://github.com/RustScan/RustScan


### PR DESCRIPTION
Hey there,

I am proposing some slight changes to the README.

1. When the `alias` is proposed, I would expect it to be fully correct and not contain any more helpers like `<rustscan arguments here>`. I think these tips are nice when the usage is first shown, but they should not appear here. I think they were added, when the Docker Image moved to `rustscan/rustscan` (see in git blame or [commit](https://github.com/RustScan/RustScan/commit/ed12888e8138e9da0d2511417556f7a43a50a759)).
2. I added the `bash` decorator to all of the markdown code blocks to enable syntax highlighting. Honestly, the result is a bit underwhelming (I expected at least some highlighting for the `docker` command ¯\\_(ツ)_/¯). It adds some minor highlighting to other commands though and it can't be wrong to have these annotations in place.
3. I thought it looked weird how there were two adjacent code blocks, so I moved them into a single one. However, now this block is the only one, where there is a `$` before the command, which is a bit odd (_open for discussion_).

I did not open an issue, because these changes are so minor and discussion could be done here. If you want me to open an issue for tracking, that is fine too. Anyway, these are just suggestions based on personal preference, so I can fully understand, if you disagree. Let me know what you guys think!

---

Thanks for your work on `rustscan`! 👍 