### PR TITLE
Introduce the -no-nmap option

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at brandon@skerritt.blog. All
+reported by contacting the project team at our discord via a private message to any of the owners. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -67,10 +67,10 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+This Code of Conduct is adapted from the Contributor Covenant homepage, version 1.4,
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-[homepage]: https://www.contributor-covenant.org
+homepage: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq

--- a/src/input.rs
+++ b/src/input.rs
@@ -68,7 +68,7 @@ pub struct Opts {
 
     /// Whether to ignore the configuration file or not.
     #[structopt(short, long)]
-    pub ignore_config: bool,
+    pub no_config: bool,
 
     /// Quiet mode. Only output the ports. No Nmap. Useful for grep or outputting to a file.
     #[structopt(short, long)]
@@ -77,6 +77,10 @@ pub struct Opts {
     /// Accessible mode. Turns off features which negatively affect screen readers.
     #[structopt(long)]
     pub accessible: bool,
+
+    /// Turns off Nmap.
+    #[structopt(long)]
+    pub no_nmap: bool,
 
     /// The batch size for port scanning, it increases or slows the speed of
     /// scanning. Depends on the open file limit of your OS.  If you do 65535
@@ -125,7 +129,7 @@ impl Opts {
     /// Reads the command line arguments into an Opts struct and merge
     /// values found within the user configuration file.
     pub fn merge(&mut self, config: &Config) {
-        if !self.ignore_config {
+        if !self.no_config {
             self.merge_required(&config);
             self.merge_optional(&config);
         }
@@ -180,6 +184,7 @@ pub struct Config {
     accessible: Option<bool>,
     batch_size: Option<u16>,
     timeout: Option<u32>,
+    no_nmap: Option<bool>,
     ulimit: Option<rlimit::rlim>,
     scan_order: Option<ScanOrder>,
     command: Option<Vec<String>>,
@@ -241,8 +246,9 @@ mod tests {
             ulimit: None,
             command: vec![],
             accessible: false,
+            no_nmap: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: true,
+            no_config: true,
         };
 
         let config = Config {
@@ -253,6 +259,7 @@ mod tests {
             batch_size: Some(25_000),
             timeout: Some(1_000),
             ulimit: None,
+            no_nmap: Some(false),
             command: Some(vec!["-A".to_owned()]),
             accessible: Some(true),
             scan_order: Some(ScanOrder::Random),
@@ -281,12 +288,14 @@ mod tests {
             command: vec![],
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_nmap: false,
+            no_config: false,
         };
 
         let config = Config {
             ips_or_hosts: Some(vec!["127.0.0.1".to_owned()]),
             ports: None,
+            no_nmap: Some(false),
             range: None,
             quiet: Some(true),
             batch_size: Some(25_000),
@@ -320,7 +329,8 @@ mod tests {
             command: vec![],
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_nmap: false,
+            no_config: false,
         };
 
         let config = Config {
@@ -333,6 +343,7 @@ mod tests {
             quiet: None,
             batch_size: None,
             timeout: None,
+            no_nmap: Some(false),
             ulimit: Some(1_000),
             command: None,
             accessible: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let batch_size = infer_batch_size(&opts, 120);
 
@@ -297,7 +298,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let batch_size = infer_batch_size(&opts, 9_000);
 
@@ -318,7 +320,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let batch_size = infer_batch_size(&opts, 5_000);
 
@@ -338,7 +341,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let batch_size = adjust_ulimit_size(&opts);
 
@@ -363,7 +367,8 @@ mod tests {
             command: Vec::new(),
             accessible: true,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
 
         infer_batch_size(&opts, 1_000_000);
@@ -384,7 +389,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let ips = parse_ips(&opts);
 
@@ -404,7 +410,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let ips = parse_ips(&opts);
 
@@ -424,7 +431,8 @@ mod tests {
             command: Vec::new(),
             accessible: false,
             scan_order: ScanOrder::Serial,
-            ignore_config: false,
+            no_config: false,
+            no_nmap: false,
         };
         let ips = parse_ips(&opts);
 


### PR DESCRIPTION
As the name implies this will allow RustScan to to run the scan without starting an nmap scan with ports that are found.

This is basically a copy of: #196