### PR TITLE
Bugfixes

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -60,18 +60,19 @@ impl Scanner {
             }
         }
 
-        while ftrs.len() <= self.batch_size as usize {
+        while ftrs.len() < self.batch_size as usize {
             if !targets.is_empty() {
                 ftrs.push(self.scan_socket(targets.pop_front().unwrap()));
+            } else {
+                break;
             }
         }
 
         loop {
             match ftrs.next().await {
                 Some(result) => {
-                    match result {
-                        Ok(socket) => open_sockets.push(socket),
-                        Err(_) => {}
+                    if let Ok(socket) = result {
+                        open_sockets.push(socket);
                     }
                     if !targets.is_empty() {
                         ftrs.push(self.scan_socket(targets.pop_front().unwrap()));


### PR DESCRIPTION
While loop logic adding sockets to the FuturesUnordered stream rolled back to the initial. 

In case of batchsize higher than all sockets to scan, we could end up in an infinite loop. Fixed with breaking out of the loop if that's the case.

Changing a small abstraction to if let Ok() where we only care about the ok value. 1 line less compared to the current one.