### PR TITLE
Runtime measurement implementation, better debugging, and better error handling for unreachable hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ This program, by default, scans 5000 ports at a time (5000 per second).
 
 This may cause damage to a server, or may make it incredibly obvious you are scanning the server.
 
+Servers as well as individual services listening on ports can block your ip completely after a huge amount of simultaneous connections/tries. 
+Possibly causing you to see false positives (open ports at the initial scanning process later found closed when you want to do further scanning, or connect to it).
+
 There are 2 ways to deal with this;
 
 1. Decrease batch size

--- a/src/port_strategy/mod.rs
+++ b/src/port_strategy/mod.rs
@@ -8,6 +8,7 @@ use range_iterator::RangeIterator;
 ///
 /// Right now all these options involve ranges, but in the future
 /// it will also contain custom lists of ports.
+#[derive(Debug)]
 pub enum PortStrategy {
     Manual(Vec<u16>),
     Serial(SerialRange),
@@ -58,6 +59,7 @@ trait RangeOrder {
 
 /// As the name implies SerialRange will always generate a vector in
 /// ascending order.
+#[derive(Debug)]
 pub struct SerialRange {
     start: u16,
     end: u16,
@@ -71,6 +73,7 @@ impl RangeOrder for SerialRange {
 
 /// As the name implies RandomRange will always generate a vector with
 /// a random order. This vector is built following the LCG algorithm.
+#[derive(Debug)]
 pub struct RandomRange {
     start: u16,
     end: u16,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -128,7 +128,6 @@ impl Scanner {
                         // );
                         debug!("Socket connect error: {} {}", &e.to_string(), &socket);
                         Err(io::Error::new(io::ErrorKind::Other, e.to_string()))
-                    // std::process::exit(1);
                     } else {
                         debug!("Socket connect error: {} {}", &e.to_string(), &socket);
                         panic!("Too many open files. Please reduce batch size. The default is 5000. Try -b 2500.");
@@ -156,8 +155,6 @@ impl Scanner {
             async move { TcpStream::connect(socket).await },
         )
         .await?;
-        // let newtimeout = &self.timeout;
-        // *&self.timeout = *newtimeout;
         Ok(stream)
     }
 }


### PR DESCRIPTION
Basic runtime measurement implemented with environment variable.

Usage
```
RUST_LOG=info ./rustscan

[2020-09-14T19:42:20Z INFO  rustscan] Portscan runtime:   44159ms
[2020-09-14T19:42:20Z INFO  rustscan] Nmap scan runtime:  240ms
[2020-09-14T19:42:20Z INFO  rustscan] RustScan runtime    44477ms 
[2020-09-14T19:42:20Z INFO  rustscan] Ports scanned       65534
[2020-09-14T19:42:20Z INFO  rustscan] It took             0ms to scan an individual port
```

Error handling clarification at unreachable hosts. Possibly fixes bug calling CIDR or bigger ip range with rustscan.

README warning addition

Basic debuggin is now possible with `RUST_LOG=debug ./rustscan` to get rich information on the spot if a scan fails for "no reason".
