### PR TITLE
socket_iterator: use itertools.iproducts for ip x ports set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +518,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -833,6 +848,7 @@ dependencies = [
  "env_logger",
  "futures",
  "gcd",
+ "itertools",
  "log",
  "rand",
  "rlimit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ toml = "0.5.6"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 cidr-utils = "0.5.0"
+itertools = "0.9.0"
 
 [package.metadata.deb]
 depends = "$auto, nmap"


### PR DESCRIPTION
PR replaces the current manual iterator-like implementation in scanner/socket_iterator.rs
with the call to the itertools.iproduct macro [1] to generate the cartesian product
of the IPs and ports. I believe the reduction of the `SocketIterator` member variables and removing
the "manual" tracking of indexes and lengths makes the code easier to read and understand.

[1]
https://docs.rs/itertools/0.9.0/itertools/macro.iproduct.html