### PR TITLE
Update Dockerfile to encourage layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM rust:alpine as builder
+LABEL maintainer="CMNatic <https://github.com/CMNatic">
 RUN apk add --no-cache build-base
 
+# Encourage some layer caching here rather then copying entire directory that includes docs to builder container ~CMN
 WORKDIR /usr/src/rustscan
-COPY . .
+COPY Cargo.toml Cargo.lock ./
+COPY src src
 RUN cargo install --path .
 
 FROM alpine:3.12


### PR DESCRIPTION
At the moment the Dockerfile brings the entire current directory in as a context for the building container. We can encourage some caching here by only bringing forward the essentials:
`cargo.tml`, `cargo.lock` and the `src`

Dockerfile has been built and tested locally to confirm it works. This is a prerequisite to the changes I'm making on the DockerHub to improve CI.

Added maintainer label to keep original accreditation

## TLDR:

+ Specified directories and files that **need** to be copied into the container for building as opposed to copying all the files as previous
+ Added a maintainer label