### PR TITLE
Scripting Engine Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
 name = "js-sys"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1131,7 @@ name = "rustscan"
 version = "1.10.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "async-std",
  "cidr-utils",
  "colored",
@@ -1135,10 +1148,18 @@ dependencies = [
  "serde_derive",
  "shell-words",
  "structopt",
+ "subprocess",
+ "text_placeholder",
  "toml",
  "trust-dns-resolver",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "sct"
@@ -1155,16 +1176,30 @@ name = "serde"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1234,6 +1269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b9ad6c3e1b525a55872a4d2f2d404b3c959b7bbcbfd83c364580f68ed157bd"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1296,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "text_placeholder"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd6afcbe8d748e35406f4c3a79b60567a5104b451f1b618097f139294969ef4"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ serde_derive = "1.0.116"
 cidr-utils = "0.5.0"
 itertools = "0.9.0"
 trust-dns-resolver = { version = "0.19.5", features = ["dns-over-rustls"] }
+anyhow = "1.0.33"
+subprocess = "0.2.6"
+text_placeholder = { version = "0.4", features = ["struct_context"] }
 
 [dev-dependencies]
 wait-timeout = "0.2"

--- a/fixtures/test_rustscan_scripts.toml
+++ b/fixtures/test_rustscan_scripts.toml
@@ -1,0 +1,14 @@
+# Test/Example ScriptConfig file
+
+# Tags to filter on scripts. Only scripts containing all these tags will run.
+tags = ["core_approved", "example"]
+
+# If it's present then only those scripts will run which has a tag ports = "80". Not yet implemented.
+#
+# ex.:
+# ports = [80]
+# ports = [80,81,8080]
+ports = [80]
+
+# Only this developer(s) scripts to run. Not yet implemented.
+developer = ["example"]

--- a/fixtures/test_script.pl
+++ b/fixtures/test_script.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+#tags = ["core_approved", "example",]
+#developer = [ "example", "https://example.org" ]
+#ports_separator = ","
+#call_format = "perl {{script}} {{ip}} {{port}}"
+
+# Sriptfile parser stops at the first blank line with parsing.
+# This script will run itself as an argument with the system installed perl interpreter, ports will be concatenated with "," .
+# Unused field: trigger_port = "80"
+# get total arg passed to this script
+my $total = $#ARGV + 1;
+my $counter = 1;
+ 
+# get script name
+my $scriptname = $0;
+ 
+print "Total args passed to $scriptname : $total\n";
+ 
+# Use loop to print all args stored in an array called @ARGV
+foreach my $a(@ARGV) {
+	print "Arg # $counter : $a\n";
+	$counter++;
+}

--- a/fixtures/test_script.py
+++ b/fixtures/test_script.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+#tags = ["core_approved", "example",]
+#developer = [ "example", "https://example.org" ]
+#trigger_port = "80"
+#call_format = "python3 {{script}} {{ip}} {{port}}"
+
+# Sriptfile parser stops at the first blank line with parsing.
+# This script will run itself as an argument with the system installed python interpreter, only scanning port 80.
+# Unused filed: ports_separator = ","
+
+import sys
+
+print('Python script ran with arguments', str(sys.argv))

--- a/fixtures/test_script.sh
+++ b/fixtures/test_script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash 
+#tags = ["core_approved", "example",]
+#developer = [ "example", "https://example.org" ]
+#ports_separator = ","
+#call_format = "bash {{script}} {{ip}} {{port}}"
+
+# Sriptfile parser stops at the first blank line with parsing.
+# This script will run itself as an argument with the system installed bash interpreter, scanning all ports concatenated with "," .
+# Unused filed: trigger_port = "80"
+
+# print all arguments passed to the script
+echo $@

--- a/fixtures/test_script.txt
+++ b/fixtures/test_script.txt
@@ -1,0 +1,9 @@
+#!intentional_blank_line
+#tags = ["core_approved", "example"]
+#developer = [ "example", "https://example.org" ]
+#ports_separator = ","
+#call_format = "nmap -vvv -p {{port}} {{ip}}"
+
+# Sriptfile parser stops at the first blank line with parsing.
+# This script will run the system installed nmap, ports will be concatenated with "," .
+# Unused field: trigger_port = "80"

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -106,11 +106,7 @@ impl Scanner {
     async fn scan_socket(&self, socket: SocketAddr) -> io::Result<SocketAddr> {
         let tries = self.tries.get();
 
-        debug!("self.tries: {}", tries);
-
         for nr_try in 1..=tries {
-            debug!("Try number: {}", nr_try);
-
             match self.connect(socket).await {
                 Ok(x) => {
                     debug!(

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,0 +1,355 @@
+//! Scripting engine to run scripts based on tags.
+//! This module serves to filter and run the scripts selected by the user.
+//!
+//! A new commandline and configuration file option was added.
+//!
+//! --scripts
+//!
+//!      default
+//!          This is the default behavior, like as it was from the beginning of RustScan.
+//!          The user do not have to chose anything for this. This is the only script embedded in RustScan running as default.
+//!
+//!      none
+//!          The user have to use the --scripts none commandline argument or scripts = "none" in the config file.
+//!          None of the scripts will run, this replaces the removed --no-nmap option.
+//!
+//!      custom
+//!          The user have to use the --scripts custom commandline argument or scripts = "custom" in the config file.
+//!          Rustscan will look for the script configuration file in the user's home dir: home_dir/.rustscan_scripts.toml
+//!          The config file have 3 optional fields, tag, developer and port. Just the tag field will be used forther in the process.
+//!          RustScan will also look for available scripts in the user's home dir: home_dir/.rustscan_scripts
+//!          and will try to read all the files, and parse them into a vector of ScriptFiles.
+//!          Filtering on tags means the tags found in the rustscan_scripts.toml file will also have to be present in the Scriptfile,
+//!          otherwise the script will not be selected.
+//!          All of the rustscan_script.toml tags have to be present at minimum in a Scriptfile to get selected, but can be also more.
+//!
+//! Config file example:
+//! fixtures/test_rustscan_scripts.toml
+//!
+//! Script file examples:
+//! fixtures/test_script.py
+//! fixtures/test_script.pl
+//! fixtures/test_script.sh
+//! fixtures/test_script.txt
+//!
+//! call_format in script files can be of 2 variants.
+//! One is where all of the possible tags {{script}} {{ip}} {{port}} are there.
+//!     The {{script}} part will be replaced with the scriptfile full path gathered while parsing available scripts.
+//!     The {{ip}} part will be replaced with the ip we got from the scan.
+//!     The {{port}} part will be reaplced with the ports separated with the ports_separator found in the script file
+//!
+//! And when there is only {{ip}} and {{port}} is in the format, ony those will be replaced with the arguments from the scan.
+//! This makes it easy to run a system installed command like nmap, and give any kind of arguments to it.
+//!
+//! If the format is different, the script will be silently discarded and will not run. With the Debug option it's possible to see where it goes wrong.
+
+use crate::input::ScriptsRequired;
+use anyhow::{anyhow, Result};
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::{self, prelude::*};
+use std::net::IpAddr;
+use std::path::PathBuf;
+use subprocess::{Exec, ExitStatus};
+use text_placeholder::Template;
+
+static DEFAULT: &'static str = r#"tags = ["core_approved", "RustScan", "default"]
+developer = [ "RustScan", "https://github.com/RustScan" ]
+ports_separator = ","
+call_format = "nmap -vvv -p {{port}} {{ip}}"
+"#;
+
+pub fn init_scripts(scripts: ScriptsRequired) -> Result<Vec<ScriptFile>> {
+    let mut scripts_to_run: Vec<ScriptFile> = Vec::new();
+
+    match scripts {
+        ScriptsRequired::None => Ok(scripts_to_run),
+        ScriptsRequired::Default => {
+            let default_script =
+                toml::from_str::<ScriptFile>(&DEFAULT).expect("Failed to parse Script file.");
+            scripts_to_run.push(default_script);
+            Ok(scripts_to_run)
+        }
+        ScriptsRequired::Custom => {
+            let scripts_dir_base = match dirs::home_dir() {
+                Some(dir) => dir,
+                None => return Err(anyhow!("Could not infer scripts path.")),
+            };
+            let script_paths = match find_scripts(scripts_dir_base) {
+                Ok(script_paths) => script_paths,
+                Err(e) => return Err(anyhow!(e)),
+            };
+            debug!("Scripts paths \n{:?}", script_paths);
+
+            let parsed_scripts = parse_scripts(script_paths);
+            debug!("Scripts parsed \n{:?}", parsed_scripts);
+
+            let script_config = match ScriptConfig::read_config() {
+                Ok(script_config) => script_config,
+                Err(e) => return Err(anyhow!(e)),
+            };
+            debug!("Script config \n{:?}", script_config);
+
+            // Only Scripts that contain all the tags found in ScriptConfig will be selected.
+            if script_config.tags.is_some() {
+                let config_hashset: HashSet<String> =
+                    script_config.tags.unwrap().into_iter().collect();
+                for script in &parsed_scripts {
+                    if script.tags.is_some() {
+                        let script_hashset: HashSet<String> =
+                            script.tags.clone().unwrap().into_iter().collect();
+                        if config_hashset.is_subset(&script_hashset) {
+                            scripts_to_run.push(script.to_owned());
+                        } else {
+                            debug!(
+                                "\nScript tags does not match config tags {:?} {}",
+                                &script_hashset,
+                                script.path.clone().unwrap().display()
+                            );
+                        }
+                    }
+                }
+            }
+            debug!("\nScript(s) to run {:?}", scripts_to_run);
+            Ok(scripts_to_run)
+        }
+    }
+}
+
+pub fn parse_scripts(scripts: Vec<PathBuf>) -> Vec<ScriptFile> {
+    let mut parsed_scripts: Vec<ScriptFile> = Vec::with_capacity(scripts.len());
+    for script in scripts {
+        debug!("Parsing script {}", &script.display());
+        if let Some(script_file) = ScriptFile::new(script) {
+            parsed_scripts.push(script_file);
+        }
+    }
+    parsed_scripts
+}
+
+#[derive(Clone, Debug)]
+pub struct Script {
+    // Path to the script itself.
+    path: Option<PathBuf>,
+
+    // Ip got from scanner.
+    ip: IpAddr,
+
+    // Ports found with portscan.
+    open_ports: Vec<u16>,
+
+    // Port found in ScriptFile, if defined only this will run with the ip.
+    trigger_port: Option<String>,
+
+    // Character to join ports in case we want to use a string format of them, for example nmap -p.
+    ports_separator: Option<String>,
+
+    // Tags found in ScriptFile.
+    tags: Option<Vec<String>>,
+
+    // The format how we want the script to run.
+    call_format: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ExecPartsScript {
+    script: String,
+    ip: String,
+    port: String,
+}
+
+#[derive(Serialize)]
+struct ExecParts {
+    ip: String,
+    port: String,
+}
+
+impl Script {
+    pub fn build(
+        path: Option<PathBuf>,
+        ip: IpAddr,
+        open_ports: Vec<u16>,
+        trigger_port: Option<String>,
+        ports_separator: Option<String>,
+        tags: Option<Vec<String>>,
+        call_format: Option<String>,
+    ) -> Self {
+        Self {
+            path: path,
+            ip: ip,
+            open_ports: open_ports,
+            trigger_port: trigger_port,
+            ports_separator: ports_separator,
+            tags: tags,
+            call_format: call_format,
+        }
+    }
+
+    // Some variables get changed before read, and compiler throws warning on warn(unused_assignments)
+    #[allow(unused_assignments)]
+    pub fn run(self) -> Result<String> {
+        debug!("run self {:?}", &self);
+
+        let separator = self.ports_separator.unwrap_or(",".into());
+
+        let mut ports_str = self
+            .open_ports
+            .iter()
+            .map(|port| port.to_string())
+            .collect::<Vec<String>>()
+            .join(&separator);
+        if let Some(port) = self.trigger_port {
+            ports_str = port;
+        }
+
+        let mut final_call_format = String::new();
+        if let Some(call_format) = self.call_format {
+            final_call_format = call_format;
+        } else {
+            return Err(anyhow!("Failed to parse execution format."));
+        }
+        let default_template: Template = Template::new(&final_call_format);
+        let mut to_run = String::new();
+
+        if final_call_format.contains("{{script}}") {
+            let exec_parts_script: ExecPartsScript = ExecPartsScript {
+                script: self.path.unwrap().to_str().unwrap().to_string(),
+                ip: self.ip.to_string(),
+                port: ports_str,
+            };
+            to_run = default_template.fill_with_struct(&exec_parts_script)?;
+        } else {
+            let exec_parts: ExecParts = ExecParts {
+                ip: self.ip.to_string(),
+                port: ports_str,
+            };
+            to_run = default_template.fill_with_struct(&exec_parts)?;
+        }
+
+        debug!("\nTo run {}", to_run);
+
+        let arguments = shell_words::split(
+            &to_run
+                .split(" ")
+                .map(|arg| arg.to_string())
+                .collect::<Vec<String>>()
+                .join(" "),
+        )
+        .expect("Failed to parse script arguments");
+
+        match execute_script(arguments) {
+            Ok(result) => return Ok(result),
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+fn execute_script(mut arguments: Vec<String>) -> Result<String> {
+    debug!("\nArguments vec: {:?}", &arguments);
+    let process = Exec::cmd(&arguments.remove(0)).args(&arguments);
+    match process.capture() {
+        Ok(c) => {
+            let es = match c.exit_status {
+                ExitStatus::Exited(c) => c as i32,
+                ExitStatus::Signaled(c) => c as i32,
+                ExitStatus::Other(c) => c,
+                _ => -1,
+            };
+            if es != 0 {
+                return Err(anyhow!("Exit code = {}", es));
+            }
+            Ok(c.stdout_str())
+        }
+        Err(error) => {
+            debug!("Command error {}", error.to_string());
+            return Err(anyhow!(error.to_string()));
+        }
+    }
+}
+
+pub fn find_scripts(mut path: PathBuf) -> Result<Vec<PathBuf>> {
+    path.push(".rustscan_scripts");
+    if path.is_dir() {
+        debug!("Scripts folder found {}", &path.display());
+        let mut files_vec: Vec<PathBuf> = Vec::new();
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            files_vec.push(entry.path());
+        }
+        return Ok(files_vec);
+    } else {
+        return Err(anyhow!("Can't find scripts folder"));
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScriptFile {
+    pub path: Option<PathBuf>,
+    pub tags: Option<Vec<String>>,
+    pub developer: Option<Vec<String>>,
+    pub port: Option<String>,
+    pub ports_separator: Option<String>,
+    pub call_format: Option<String>,
+}
+
+impl ScriptFile {
+    fn new(script: PathBuf) -> Option<ScriptFile> {
+        let real_path = script.clone();
+        let mut lines_buf = String::new();
+        if let Ok(file) = File::open(script) {
+            for line in io::BufReader::new(file).lines().skip(1) {
+                if let Ok(mut line) = line {
+                    if line.starts_with("#") {
+                        line.retain(|c| c != '#');
+                        line = line.trim().to_string();
+                        line.push_str("\n");
+                        lines_buf.push_str(&line);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        } else {
+            debug!("Failed to read file: {}", &real_path.display());
+            return None;
+        }
+        debug!("ScriptFile {} lines\n{}", &real_path.display(), &lines_buf);
+
+        match toml::from_str::<ScriptFile>(&lines_buf) {
+            Ok(mut parsed) => {
+                debug!("Parsed ScriptFile{} \n{:?}", &real_path.display(), &parsed);
+                parsed.path = Some(real_path);
+                // parsed_scripts.push(parsed);
+                return Some(parsed);
+            }
+            Err(e) => {
+                debug!("Failed to parse ScriptFile headers {}", e.to_string());
+                return None;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ScriptConfig {
+    pub tags: Option<Vec<String>>,
+    pub ports: Option<Vec<String>>,
+    pub developer: Option<Vec<String>>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl ScriptConfig {
+    pub fn read_config() -> Result<ScriptConfig> {
+        let mut home_dir = match dirs::home_dir() {
+            Some(dir) => dir,
+            None => return Err(anyhow!("Could not infer ScriptConfig path.")),
+        };
+        home_dir.push(".rustscan_scripts.toml");
+
+        let content = fs::read_to_string(home_dir)?;
+        let config = toml::from_str::<ScriptConfig>(&content)?;
+        Ok(config)
+    }
+}


### PR DESCRIPTION
I started to implement the scripting engine how I thought it could work smooth. We can make this structure dynamic enugh to fill in all the necessary info we talked about before, like `core_approved` and description of the script. My idea would be to make the interpreted language files in a self contained way, which means the first 4-5 lines of the file could contain the tags in comment space for the interpreter, and the rest of the file can be the script itself.
I'm not sure how we should handle binary files, if the user want's to run a binary we have to store the tags on a different location.

For a main rustscan_scripting config file we could use toml format, where we store some basic variables in case we have any. To read the scripting config, we could add a new arg like `--scripting`

```
tags = ["core_approved", ""]


# optional field, if it's given then only those scripts will run which has a tag ports = [80]
# 
# ex.: 
# ports = [80] 
# ports = [80,81,8080]
ports = [80]


# optional field, if it's given, only that(those) interpreter(s) will be used 
# 
interpreters = ["python3", "bash"]
```

Please check it out how it looks and give comments how to imporve, or if it's even a good idea to do it this way. @bee-san @bernardoamc @CMNatic 