### PR TITLE
Update documentation to include greppable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,11 @@ USAGE:
 
 FLAGS:
         --accessible    Accessible mode. Turns off features which negatively affect screen readers
+    -g, --greppable     Greppable mode. Only output the ports. No Nmap. Useful for grep or outputting to a file
     -h, --help          Prints help information
     -n, --no-config     Whether to ignore the configuration file or not
         --no-nmap       Turns off Nmap
-    -q, --quiet         Quiet mode. Only output the ports. No Nmap. Useful for grep or outputting to a file
+        --top           Use the top 1000 ports
     -V, --version       Prints version information
 
 OPTIONS:
@@ -246,7 +247,7 @@ OPTIONS:
 ARGS:
     <addresses>...    A list of comma separated CIDRs, IPs, or hosts to be scanned
     <command>...      The Nmap arguments to run. To use the argument -A, end RustScan's args with '-- -A'. Example:
-                      'rustscan -t 1500 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS automatically to
+                      'rustscan -T 1500 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS automatically to
                       nmap. For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and
                       vuln)'\"")
 ```
@@ -268,7 +269,7 @@ and accepts the following fields:
 - `scan_order`
 - `command`
 - `accessible`
-- `quiet`
+- `greppable`
 - `batch-size`
 - `timeout`
 - `ulimit`
@@ -280,7 +281,7 @@ addresses = ["127.0.0.1", "192.168.0.0/30", "www.google.com"]
 command = ["-A"]
 ports = [80, 443, 8080]
 range = { start = 1, end = 10 }
-quiet = false
+greppable = false
 accessible = true
 scan_order = "Serial"
 batch_size = 1000

--- a/src/input.rs
+++ b/src/input.rs
@@ -210,7 +210,7 @@ impl Config {
     ///
     /// addresses = ["127.0.0.1", "127.0.0.1"]
     /// ports = [80, 443, 8080]
-    /// quiet = true
+    /// greppable = true
     /// scan_order: "Serial"
     ///
     pub fn read() -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
         // nmap port style is 80,443. Comma separated with no spaces.
         let ports_str = nmap_str_ports.join(",");
 
-        // if quiet mode is on nmap should not be spawned
+        // if greppable mode is on nmap should not be spawned
         if opts.greppable || opts.no_nmap {
             println!("{} -> [{}]", &ip, ports_str);
             continue;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -19,7 +19,7 @@ use std::{
 /// start & end is where the port scan starts and ends
 /// batch_size is how many ports at a time should be scanned
 /// Timeout is the time RustScan should wait before declaring a port closed. As datatype Duration.
-/// Quiet is whether or not RustScan should print things, or wait until the end to print only open ports.
+/// greppable is whether or not RustScan should print things, or wait until the end to print only the ip and open ports.
 #[cfg(not(tarpaulin_include))]
 #[derive(Debug)]
 pub struct Scanner {


### PR DESCRIPTION
Update some legacy documentation that might lead to errors. I notice that the quiet mode is no longer called quiet but greppable. 

Just updated bunch of files where quiet mode was mention. 