### PR TITLE
Add integration tests with timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
 script:
 - cargo build
 - cargo test
+- ulimit -n 5000; cargo test timelimits:: -- --ignored --test-threads=1
 - cargo fmt -- --check
 after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
 script:
 - cargo build
 - cargo test
-- ulimit -n 5000; cargo test timelimits:: -- --ignored --test-threads=1
+- "ulimit -n 5000; cargo test timelimits:: -- --ignored --test-threads=1"
 - cargo fmt -- --check
 after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
 script:
 - cargo build
 - cargo test
-- "ulimit -n 5000; cargo test timelimits:: -- --ignored --test-threads=1"
+- "ulimit -n 5000; cargo test timelimits:: -- --ignored --test-threads=1 --show-output"
 - cargo fmt -- --check
 after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "structopt",
  "toml",
  "trust-dns-resolver",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1462,6 +1463,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ cidr-utils = "0.5.0"
 itertools = "0.9.0"
 trust-dns-resolver = { version = "0.19.5", features = ["dns-over-rustls"] }
 
+[dev-dependencies]
+wait-timeout = "0.2"
+
 [package.metadata.deb]
 depends = "$auto, nmap"
 section = "rust"

--- a/tests/timelimits.rs
+++ b/tests/timelimits.rs
@@ -36,33 +36,57 @@ mod timelimits {
     #[ignore]
     fn scan_localhost() {
         let timeout = super::Duration::from_secs(3);
-        super::run_rustscan_with_timeout(
-            &["--greppable", "--no-nmap", "127.0.0.1"],
-            timeout,
-        );
+        super::run_rustscan_with_timeout(&["--greppable", "--no-nmap", "127.0.0.1"], timeout);
     }
 
     #[test]
     #[ignore]
     fn scan_google_com() {
         super::run_rustscan_with_timeout(
-            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "google.com"],
-            super::Duration::from_secs(28));
+            &[
+                "--greppable",
+                "--no-nmap",
+                "-u",
+                "5000",
+                "-b",
+                "2500",
+                "google.com",
+            ],
+            super::Duration::from_secs(28),
+        );
     }
 
     #[test]
     #[ignore]
     fn scan_example_com() {
         super::run_rustscan_with_timeout(
-            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "example.com"],
-            super::Duration::from_secs(28));
+            &[
+                "--greppable",
+                "--no-nmap",
+                "-u",
+                "5000",
+                "-b",
+                "2500",
+                "example.com",
+            ],
+            super::Duration::from_secs(28),
+        );
     }
 
     #[test]
     #[ignore]
     fn scan_rustscan_cmnatic_co_uk() {
         super::run_rustscan_with_timeout(
-            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "rustscan.cmnatic.co.uk"],
-            super::Duration::from_secs(26));
+            &[
+                "--greppable",
+                "--no-nmap",
+                "-u",
+                "5000",
+                "-b",
+                "2500",
+                "rustscan.cmnatic.co.uk",
+            ],
+            super::Duration::from_secs(26),
+        );
     }
 }

--- a/tests/timelimits.rs
+++ b/tests/timelimits.rs
@@ -1,0 +1,68 @@
+/*
+ * Test rustscan against different targets with a time limit.
+ * The tests assumes target/debug/rustscan has already been built.
+ *
+ * The tests are #[ignore] to avoid running them during normal development.
+ *
+ * Their tests in the timelimits module are run by travis during CI.
+ */
+
+use std::process::Command;
+use std::time::Duration;
+use wait_timeout::ChildExt;
+
+fn run_rustscan_with_timeout(args: &[&str], timeout: Duration) {
+    println!("Running: target/debug/rustscan: {}", args.join(" "));
+
+    let mut child = Command::new("target/debug/rustscan")
+        .args(args)
+        .spawn()
+        .unwrap();
+
+    let _status_code = match child.wait_timeout(timeout).unwrap() {
+        Some(status) => status.code(),
+        None => {
+            // child hasn't exited yet
+            child.kill().unwrap();
+            child.wait().unwrap().code();
+            panic!("Timeout while running command");
+        }
+    };
+}
+
+mod timelimits {
+
+    #[test]
+    #[ignore]
+    fn scan_localhost() {
+        let timeout = super::Duration::from_secs(3);
+        super::run_rustscan_with_timeout(
+            &["--greppable", "--no-nmap", "127.0.0.1"],
+            timeout,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn scan_google_com() {
+        super::run_rustscan_with_timeout(
+            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "google.com"],
+            super::Duration::from_secs(28));
+    }
+
+    #[test]
+    #[ignore]
+    fn scan_example_com() {
+        super::run_rustscan_with_timeout(
+            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "example.com"],
+            super::Duration::from_secs(28));
+    }
+
+    #[test]
+    #[ignore]
+    fn scan_rustscan_cmnatic_co_uk() {
+        super::run_rustscan_with_timeout(
+            &["--greppable", "--no-nmap", "-u", "5000", "-b", "2500", "rustscan.cmnatic.co.uk"],
+            super::Duration::from_secs(26));
+    }
+}

--- a/tests/timelimits.rs
+++ b/tests/timelimits.rs
@@ -11,6 +11,9 @@ use std::process::Command;
 use std::time::Duration;
 use wait_timeout::ChildExt;
 
+const TIMEOUT_MULTIPLIER: f32 = 2.0;
+const TIMEOUT_MARGIN_SECONDS: Duration = Duration::from_secs(3);
+
 fn run_rustscan_with_timeout(args: &[&str], timeout: Duration) {
     println!("Running: target/debug/rustscan: {}", args.join(" "));
 
@@ -18,6 +21,8 @@ fn run_rustscan_with_timeout(args: &[&str], timeout: Duration) {
         .args(args)
         .spawn()
         .unwrap();
+
+    let timeout = timeout * ((TIMEOUT_MULTIPLIER * 10.0) as u32) / 10 + TIMEOUT_MARGIN_SECONDS;
 
     let _status_code = match child.wait_timeout(timeout).unwrap() {
         Some(status) => status.code(),


### PR DESCRIPTION
Add tests in the timelimits:: module to run scans against different hosts and fail if it takes too long.
Fixes #247 