### PR TITLE
Add tries to scan_socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ OPTIONS:
                                      ascending order while the "random" option will scan ports randomly [default:
                                      serial]  [possible values: Serial, Random]
     -t, --timeout <timeout>          The timeout in milliseconds before a port is assumed to be closed [default: 1500]
+        --tries <tries>              The number of tries before a port is assumed to be closed. If set to 0, rustscan
+                                     will correct it to 1 [default: 1]
     -u, --ulimit <ulimit>            Automatically ups the ULIMIT with the value you provided
 
 ARGS:
@@ -260,7 +262,7 @@ Your operating system may not support this, but it is worth it to play around an
 
 ## Configuration file
 
-This binary accepts a configuration file that is read from the home directory of the user. It follows the TOML format
+This binary accepts a configuration file, named `.rustscan.toml`, that is read from the home directory of the user. It follows the TOML format
 and accepts the following fields:
 
 - `addresses`
@@ -272,6 +274,7 @@ and accepts the following fields:
 - `greppable`
 - `batch-size`
 - `timeout`
+- `tries`
 - `ulimit`
 
 ### Format example
@@ -286,6 +289,7 @@ accessible = true
 scan_order = "Serial"
 batch_size = 1000
 timeout = 1000
+tries = 3
 ulimit = 1000
 ```
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -95,6 +95,11 @@ pub struct Opts {
     #[structopt(short, long, default_value = "1500")]
     pub timeout: u32,
 
+    /// The number of tries before a port is assumed to be closed.
+    /// If set to 0, rustscan will correct it to 1.
+    #[structopt(long, default_value = "1")]
+    pub tries: u8,
+
     /// Automatically ups the ULIMIT with the value you provided.
     #[structopt(short, long)]
     pub ulimit: Option<rlimit::rlim>,
@@ -153,7 +158,9 @@ impl Opts {
             }
         }
 
-        merge_required!(addresses, greppable, accessible, batch_size, timeout, scan_order, command);
+        merge_required!(
+            addresses, greppable, accessible, batch_size, timeout, tries, scan_order, command
+        );
     }
 
     fn merge_optional(&mut self, config: &Config) {
@@ -195,6 +202,7 @@ pub struct Config {
     accessible: Option<bool>,
     batch_size: Option<u16>,
     timeout: Option<u32>,
+    tries: Option<u8>,
     no_nmap: Option<bool>,
     ulimit: Option<rlimit::rlim>,
     scan_order: Option<ScanOrder>,
@@ -252,6 +260,7 @@ mod tests {
                 greppable: Some(true),
                 batch_size: Some(25_000),
                 timeout: Some(1_000),
+                tries: Some(1),
                 ulimit: None,
                 no_nmap: Some(false),
                 command: Some(vec!["-A".to_owned()]),
@@ -270,6 +279,7 @@ mod tests {
                 greppable: true,
                 batch_size: 0,
                 timeout: 0,
+                tries: 0,
                 ulimit: None,
                 command: vec![],
                 accessible: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
         &ips,
         batch_size,
         Duration::from_millis(opts.timeout.into()),
+        opts.tries,
         opts.greppable,
         PortStrategy::pick(opts.range, opts.ports, opts.scan_order),
         opts.accessible,


### PR DESCRIPTION
Hi.


I added a number of tries to `scan_socket`, by default the number of try is 1 but it can be set with command line option `--tries`.
This should close #38.

I am not a Rust expert, so please let me know if I wrote something wrong or not elegant.
Moreover, I am not sure of my code for the `Config` part, so this part needs to be reviewed.


Best regards.