### PR TITLE
Make address an optional instead of a positional argument

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,7 @@
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::fs;
+
 use structopt::{clap::arg_enum, StructOpt};
 
 const LOWEST_PORT_NUMBER: u16 = 1;
@@ -57,7 +58,7 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
 /// - GitHub https://github.com/RustScan/RustScan
 pub struct Opts {
     /// A list of comma separated CIDRs, IPs, or hosts to be scanned.
-    #[structopt(use_delimiter = true)]
+    #[structopt(short, long, use_delimiter = true)]
     pub addresses: Vec<String>,
 
     /// A list of comma separed ports to be scanned. Example: 80,443,8080.


### PR DESCRIPTION
This has the benefit of making the input flexible and fixing an existing bug that happens when a single port is specified, see #211.

Other benefits:
  - We are now parsing only failures as a file, reducing the amount of
    attempts to open a file.
  - We check if a file exists before trying to open it.

⚠️ **This is a breaking change in our API** ⚠️ 

Fixes #211