### PR TITLE
Add clippy linting and fix existing warnings

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -47,6 +47,21 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  clippy:
+    name: Clippy linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   links:
         name: markdown-link-check
         runs-on: ubuntu-latest

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -64,7 +64,7 @@ pub struct NamedTimer {
 impl NamedTimer {
     pub fn start(name: &'static str) -> Self {
         Self {
-            name: name,
+            name,
             start: Some(Instant::now()),
             end: None,
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,7 +40,7 @@ pub struct PortRange {
 #[cfg(not(tarpaulin_include))]
 fn parse_range(input: &str) -> Result<PortRange, String> {
     let range = input
-        .split("-")
+        .split('-')
         .map(|x| x.parse::<u16>())
         .collect::<Result<Vec<u16>, std::num::ParseIntError>>();
 
@@ -189,14 +189,12 @@ impl Opts {
         }
 
         // Only use top ports when the user asks for them
-        if self.top {
-            if config.ports.is_some() {
-                let mut ports: Vec<u16> = Vec::with_capacity(config.ports.clone().unwrap().len());
-                for entry in config.ports.clone().unwrap().keys() {
-                    ports.push(entry.parse().unwrap())
-                }
-                self.ports = Some(ports);
+        if self.top && config.ports.is_some() {
+            let mut ports: Vec<u16> = Vec::with_capacity(config.ports.clone().unwrap().len());
+            for entry in config.ports.clone().unwrap().keys() {
+                ports.push(entry.parse().unwrap())
             }
+            self.ports = Some(ports);
         }
 
         merge_optional!(range, ulimit);

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,13 +120,13 @@ fn main() {
 
     let mut script_bench = NamedTimer::start("Scripts");
     for (ip, ports) in ports_per_ip.iter_mut() {
-        let vec_str_ports: Vec<String> = ports.into_iter().map(|port| port.to_string()).collect();
+        let vec_str_ports: Vec<String> = ports.iter().map(|port| port.to_string()).collect();
 
         // nmap port style is 80,443. Comma separated with no spaces.
         let ports_str = vec_str_ports.join(",");
 
         // if option scripts is none, no script will be spawned
-        if opts.greppable || opts.scripts.clone() == ScriptsRequired::None {
+        if opts.greppable || opts.scripts == ScriptsRequired::None {
             println!("{} -> [{}]", &ip, ports_str);
             continue;
         }
@@ -136,12 +136,12 @@ fn main() {
         for mut script_f in scripts_to_run.clone() {
             output!(
                 format!("Script to be run {:?}\n", script_f.call_format,),
-                opts.greppable.clone(),
-                opts.accessible.clone()
+                opts.greppable,
+                opts.accessible
             );
 
             // This part allows us to add commandline arguments to the Script call_format, appending them to the end of the command.
-            if opts.command.len() > 0 {
+            if !opts.command.is_empty() {
                 let user_extra_args: Vec<String> = shell_words::split(&opts.command.join(" "))
                     .expect("Failed to parse extra user commandline arguments");
                 if script_f.call_format.is_some() {
@@ -163,11 +163,7 @@ fn main() {
             );
             match script.run() {
                 Ok(script_result) => {
-                    detail!(
-                        format!("{}", script_result),
-                        opts.greppable,
-                        opts.accessible
-                    );
+                    detail!(script_result.to_string(), opts.greppable, opts.accessible);
                 }
                 Err(e) => {
                     warning!(

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -82,9 +82,8 @@ impl Scanner {
                 ftrs.push(self.scan_socket(socket));
             }
 
-            match result {
-                Ok(socket) => open_sockets.push(socket),
-                _ => {}
+            if let Ok(socket) = result {
+                open_sockets.push(socket);
             }
         }
         debug!("Open Sockets found: {:?}", &open_sockets);

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -75,7 +75,7 @@ impl Scanner {
             self.batch_size,
             self.ips.len(),
             &ports.len(),
-            (self.ips.len() * &ports.len()));
+            (self.ips.len() * ports.len()));
 
         while let Some(result) = ftrs.next().await {
             if let Some(socket) = socket_iterator.next() {

--- a/src/scanner/socket_iterator.rs
+++ b/src/scanner/socket_iterator.rs
@@ -21,8 +21,8 @@ pub struct SocketIterator<'s> {
 /// generating a vector containing all these combinations.
 impl<'s> SocketIterator<'s> {
     pub fn new(ips: &'s [IpAddr], ports: &'s [u16]) -> Self {
-        let ports_it = Box::new(ports.into_iter());
-        let ips_it = Box::new(ips.into_iter());
+        let ports_it = Box::new(ports.iter());
+        let ips_it = Box::new(ips.iter());
         Self {
             product_it: iproduct!(ports_it, ips_it),
         }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -54,7 +54,7 @@ use std::path::PathBuf;
 use subprocess::{Exec, ExitStatus};
 use text_placeholder::Template;
 
-static DEFAULT: &'static str = r#"tags = ["core_approved", "RustScan", "default"]
+static DEFAULT: &str = r#"tags = ["core_approved", "RustScan", "default"]
 developer = [ "RustScan", "https://github.com/RustScan" ]
 ports_separator = ","
 call_format = "nmap -vvv -p {{port}} {{ip}}"
@@ -176,13 +176,13 @@ impl Script {
         call_format: Option<String>,
     ) -> Self {
         Self {
-            path: path,
-            ip: ip,
-            open_ports: open_ports,
-            trigger_port: trigger_port,
-            ports_separator: ports_separator,
-            tags: tags,
-            call_format: call_format,
+            path,
+            ip,
+            open_ports,
+            trigger_port,
+            ports_separator,
+            tags,
+            call_format,
         }
     }
 
@@ -231,7 +231,7 @@ impl Script {
 
         let arguments = shell_words::split(
             &to_run
-                .split(" ")
+                .split(' ')
                 .map(|arg| arg.to_string())
                 .collect::<Vec<String>>()
                 .join(" "),
@@ -301,7 +301,7 @@ impl ScriptFile {
         if let Ok(file) = File::open(script) {
             for line in io::BufReader::new(file).lines().skip(1) {
                 if let Ok(mut line) = line {
-                    if line.starts_with("#") {
+                    if line.starts_with('#') {
                         line.retain(|c| c != '#');
                         line = line.trim().to_string();
                         line.push_str("\n");

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -238,10 +238,7 @@ impl Script {
         )
         .expect("Failed to parse script arguments");
 
-        match execute_script(arguments) {
-            Ok(result) => return Ok(result),
-            Err(e) => return Err(e),
-        }
+        execute_script(arguments)
     }
 }
 
@@ -264,7 +261,7 @@ fn execute_script(mut arguments: Vec<String>) -> Result<String> {
         }
         Err(error) => {
             debug!("Command error {}", error.to_string());
-            return Err(anyhow!(error.to_string()));
+            Err(anyhow!(error.to_string()))
         }
     }
 }
@@ -278,9 +275,9 @@ pub fn find_scripts(mut path: PathBuf) -> Result<Vec<PathBuf>> {
             let entry = entry?;
             files_vec.push(entry.path());
         }
-        return Ok(files_vec);
+        Ok(files_vec)
     } else {
-        return Err(anyhow!("Can't find scripts folder"));
+        Err(anyhow!("Can't find scripts folder"))
     }
 }
 
@@ -322,11 +319,11 @@ impl ScriptFile {
                 debug!("Parsed ScriptFile{} \n{:?}", &real_path.display(), &parsed);
                 parsed.path = Some(real_path);
                 // parsed_scripts.push(parsed);
-                return Some(parsed);
+                Some(parsed)
             }
             Err(e) => {
                 debug!("Failed to parse ScriptFile headers {}", e.to_string());
-                return None;
+                None
             }
         }
     }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -191,7 +191,7 @@ impl Script {
     pub fn run(self) -> Result<String> {
         debug!("run self {:?}", &self);
 
-        let separator = self.ports_separator.unwrap_or(",".into());
+        let separator = self.ports_separator.unwrap_or_else(|| ",".into());
 
         let mut ports_str = self
             .open_ports


### PR DESCRIPTION
Closes #276

I split the stuff up into separate commits, but I guess they _could_ also be squashed.

- Fix clippy warnings around match expressions
- Fix clippy warnings about syntax
- Fix clippy warnings around return statements that could just be expressions
- Fix clippy warnings around under-specific method calls
- Add clippy workflow

I am not sure about the workflow as it uses some "secret token", but this is how it is set up over at `tealdeer`. On the project page, it says that it is used to add the annotations to the PR diff. If you don't like that, I could replace it with a workflow that just checks the lints.
