### PR TITLE
Better enforce clippy lints

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -10,7 +10,7 @@ arg_enum! {
     /// Represents the strategy in which the port scanning will run.
     ///   - Serial will run from start to end, for example 1 to 1_000.
     ///   - Random will randomize the order in which ports will be scanned.
-    #[derive(Deserialize, Debug, StructOpt, Clone, PartialEq)]
+    #[derive(Deserialize, Debug, StructOpt, Clone, Copy, PartialEq)]
     pub enum ScanOrder {
         Serial,
         Random,
@@ -41,7 +41,7 @@ pub struct PortRange {
 fn parse_range(input: &str) -> Result<PortRange, String> {
     let range = input
         .split('-')
-        .map(|x| x.parse::<u16>())
+        .map(str::parse)
         .collect::<Result<Vec<u16>, std::num::ParseIntError>>();
 
     if range.is_err() {
@@ -63,6 +63,7 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
 
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(name = "rustscan", setting = structopt::clap::AppSettings::TrailingVarArg)]
+#[allow(clippy::struct_excessive_bools)]
 /// Fast Port Scanner built in Rust.
 /// WARNING Do not use this program against sensitive infrastructure since the
 /// specified server may not be able to handle this many socket connections at once.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::doc_markdown)]
+
 extern crate shell_words;
 
 mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_markdown, clippy::if_not_else, clippy::non_ascii_literal)]
 
 extern crate shell_words;
 
@@ -26,12 +26,17 @@ use colorful::{Color, Colorful};
 use futures::executor::block_on;
 use rlimit::{getrlimit, setrlimit, RawRlim, Resource, Rlim};
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::net::{IpAddr, ToSocketAddrs};
 use std::path::Path;
+use std::string::ToString;
 use std::time::Duration;
-use trust_dns_resolver::{config::*, Resolver};
+use trust_dns_resolver::{
+    config::{ResolverConfig, ResolverOpts},
+    Resolver,
+};
 
 extern crate colorful;
 extern crate dirs;
@@ -45,6 +50,7 @@ const AVERAGE_BATCH_SIZE: RawRlim = 3000;
 extern crate log;
 
 #[cfg(not(tarpaulin_include))]
+#[allow(clippy::too_many_lines)]
 /// Faster Nmap scanning with Rust
 /// If you're looking for the actual scanning, check out the module Scanner
 fn main() {
@@ -86,7 +92,7 @@ fn main() {
         Duration::from_millis(opts.timeout.into()),
         opts.tries,
         opts.greppable,
-        PortStrategy::pick(opts.range, opts.ports, opts.scan_order),
+        PortStrategy::pick(&opts.range, opts.ports, opts.scan_order),
         opts.accessible,
     );
     debug!("Scanner finished building: {:?}", scanner);
@@ -123,8 +129,8 @@ fn main() {
     }
 
     let mut script_bench = NamedTimer::start("Scripts");
-    for (ip, ports) in ports_per_ip.iter_mut() {
-        let vec_str_ports: Vec<String> = ports.iter().map(|port| port.to_string()).collect();
+    for (ip, ports) in &ports_per_ip {
+        let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
 
         // nmap port style is 80,443. Comma separated with no spaces.
         let ports_str = vec_str_ports.join(",");
@@ -311,21 +317,18 @@ fn adjust_ulimit_size(opts: &Opts) -> RawRlim {
     if opts.ulimit.is_some() {
         let limit: Rlim = Rlim::from_raw(opts.ulimit.unwrap());
 
-        match setrlimit(Resource::NOFILE, limit, limit) {
-            Ok(_) => {
-                detail!(
-                    format!("Automatically increasing ulimit value to {}.", limit),
-                    opts.greppable,
-                    opts.accessible
-                );
-            }
-            Err(_) => {
-                warning!(
-                    "ERROR. Failed to set ulimit value.",
-                    opts.greppable,
-                    opts.accessible
-                );
-            }
+        if setrlimit(Resource::NOFILE, limit, limit).is_ok() {
+            detail!(
+                format!("Automatically increasing ulimit value to {}.", limit),
+                opts.greppable,
+                opts.accessible
+            );
+        } else {
+            warning!(
+                "ERROR. Failed to set ulimit value.",
+                opts.greppable,
+                opts.accessible
+            );
         }
     }
 
@@ -367,7 +370,9 @@ fn infer_batch_size(opts: &Opts, ulimit: RawRlim) -> u16 {
         opts.greppable, opts.accessible);
     }
 
-    batch_size as u16
+    batch_size
+        .try_into()
+        .expect("Couldn't fit the batch size into a u16.")
 }
 
 #[cfg(test)]
@@ -418,8 +423,8 @@ mod tests {
         opts.ulimit = Some(2_000);
         // print opening should not panic
         print_opening(&opts);
-        assert!(1 == 1);
     }
+
     #[test]
     fn test_high_ulimit_no_greppable_mode() {
         let mut opts = Opts::default();

--- a/src/port_strategy/mod.rs
+++ b/src/port_strategy/mod.rs
@@ -16,7 +16,7 @@ pub enum PortStrategy {
 }
 
 impl PortStrategy {
-    pub fn pick(range: Option<PortRange>, ports: Option<Vec<u16>>, order: ScanOrder) -> Self {
+    pub fn pick(range: &Option<PortRange>, ports: Option<Vec<u16>>, order: ScanOrder) -> Self {
         match order {
             ScanOrder::Serial if ports.is_none() => {
                 let range = range.as_ref().unwrap();
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn serial_strategy_with_range() {
         let range = PortRange { start: 1, end: 100 };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Serial);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Serial);
         let result = strategy.order();
         let expected_range = (1..100).into_iter().collect::<Vec<u16>>();
         assert_eq!(expected_range, result);
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn random_strategy_with_range() {
         let range = PortRange { start: 1, end: 100 };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let mut result = strategy.order();
         let expected_range = (1..100).into_iter().collect::<Vec<u16>>();
         assert_ne!(expected_range, result);
@@ -121,14 +121,14 @@ mod tests {
 
     #[test]
     fn serial_strategy_with_ports() {
-        let strategy = PortStrategy::pick(None, Some(vec![80, 443]), ScanOrder::Serial);
+        let strategy = PortStrategy::pick(&None, Some(vec![80, 443]), ScanOrder::Serial);
         let result = strategy.order();
         assert_eq!(vec![80, 443], result);
     }
 
     #[test]
     fn random_strategy_with_ports() {
-        let strategy = PortStrategy::pick(None, Some((1..10).collect()), ScanOrder::Random);
+        let strategy = PortStrategy::pick(&None, Some((1..10).collect()), ScanOrder::Random);
         let mut result = strategy.order();
         let expected_range = (1..10).into_iter().collect::<Vec<u16>>();
         assert_ne!(expected_range, result);

--- a/src/port_strategy/range_iterator.rs
+++ b/src/port_strategy/range_iterator.rs
@@ -1,5 +1,6 @@
 use gcd::Gcd;
 use rand::Rng;
+use std::convert::TryInto;
 
 pub struct RangeIterator {
     active: bool,
@@ -60,7 +61,11 @@ impl Iterator for RangeIterator {
         }
 
         self.normalized_pick = next_pick;
-        Some((self.actual_start + current_pick) as u16)
+        Some(
+            (self.actual_start + current_pick)
+                .try_into()
+                .expect("Could not convert u32 to u16"),
+        )
     }
 }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -6,7 +6,7 @@ use socket_iterator::SocketIterator;
 use async_std::io;
 use async_std::net::TcpStream;
 use async_std::prelude::*;
-use colored::*;
+use colored::Colorize;
 use futures::stream::FuturesUnordered;
 use std::{
     io::ErrorKind,
@@ -49,7 +49,7 @@ impl Scanner {
             tries: NonZeroU8::new(std::cmp::max(tries, 1)).unwrap(),
             greppable,
             port_strategy,
-            ips: ips.iter().map(|ip| ip.to_owned()).collect(),
+            ips: ips.iter().map(ToOwned::to_owned).collect(),
             accessible,
         }
     }
@@ -184,7 +184,7 @@ mod tests {
             start: 1,
             end: 1_000,
         };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -206,7 +206,7 @@ mod tests {
             start: 1,
             end: 1_000,
         };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -227,7 +227,7 @@ mod tests {
             start: 1,
             end: 1_000,
         };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -247,7 +247,7 @@ mod tests {
             start: 400,
             end: 445,
         };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -270,7 +270,7 @@ mod tests {
             start: 400,
             end: 600,
         };
-        let strategy = PortStrategy::pick(Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::non_ascii_literal)]
-
 /// Terminal User Interface Module for RustScan
 /// Defines macros to use
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::non_ascii_literal)]
+
 /// Terminal User Interface Module for RustScan
 /// Defines macros to use
 


### PR DESCRIPTION
Hey there, it's me again :D

I just saw that the clippy lints are run, but the annotations cannot be added to forked repos, so PR diffs cannot be annotated. To enforce the lints, I propose the following changes:

1. Project-wide `deny(clippy::all)`: This will have clippy error if any of the default warnings is emitted
2. Project-wide `warn(clippy::pedantic)` with whitelisting: This will nit-pick things, which is why these are just warnings. Still, I would rather allow specific lints (like I did already) where needed if it is reasonable.
3. Finally, make the clippy workflow a required pass, so that no new code that doesn't pass the default lints can be merged (I haven't figured out how to do this yet, is this some maintainer setting?)

I think 1) and 3) are needed, 2) is maybe a bit radical. Still, I think it would be a nice addition. Because the annotations are still there for code that is already on this repository, these lints can be fixed when someone is already working on the affected code. Let me know what you think!
