### PR TITLE
minor change in help section

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -132,7 +132,7 @@ pub struct Opts {
     /// To use the argument -A, end RustScan's args with '-- -A'.
     /// Example: 'rustscan -T 1500 127.0.0.1 -- -A -sC'.
     /// This command adds -Pn -vvv -p $PORTS automatically to nmap.
-    /// For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"")
+    /// For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"
     #[structopt(last = true)]
     pub command: Vec<String>,
 }


### PR DESCRIPTION
Changed this : 
For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"")
to:
For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"