### PR TITLE
Scripting engine arguments. Scan engine errors.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,19 +154,20 @@ fn main() {
 
         // Run all the scripts we found and parsed based on the script config file tags field.
         for mut script_f in scripts_to_run.clone() {
-            output!(
-                format!("Script to be run {:?}\n", script_f.call_format,),
-                opts.greppable,
-                opts.accessible
-            );
-
             // This part allows us to add commandline arguments to the Script call_format, appending them to the end of the command.
             if !opts.command.is_empty() {
-                let user_extra_args: Vec<String> = shell_words::split(&opts.command.join(" "))
-                    .expect("Failed to parse extra user commandline arguments");
+                let user_extra_args = &opts.command.join(" ");
+                debug!("Extra args vec {:?}", user_extra_args);
                 if script_f.call_format.is_some() {
                     let mut call_f = script_f.call_format.unwrap();
-                    call_f.push_str(&format!(" {}", &user_extra_args.join(" ")));
+                    call_f.push(' ');
+                    call_f.push_str(user_extra_args);
+                    output!(
+                        format!("Running script {:?} on ip {}\nDepending on the complexity of the script, results may take some time to appear.", call_f, &ip),
+                        opts.greppable,
+                        opts.accessible
+                    );
+                    debug!("Call format {}", call_f);
                     script_f.call_format = Some(call_f);
                 }
             }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -231,17 +231,9 @@ impl Script {
             };
             to_run = default_template.fill_with_struct(&exec_parts)?;
         }
+        debug!("\nScript format to run {}", to_run);
 
-        debug!("\nTo run {}", to_run);
-
-        let arguments = shell_words::split(
-            &to_run
-                .split(' ')
-                .map(ToString::to_string)
-                .collect::<Vec<String>>()
-                .join(" "),
-        )
-        .expect("Failed to parse script arguments");
+        let arguments = shell_words::split(&to_run).expect("Failed to parse script arguments");
 
         execute_script(arguments)
     }
@@ -249,7 +241,7 @@ impl Script {
 
 #[cfg(not(tarpaulin_include))]
 fn execute_script(mut arguments: Vec<String>) -> Result<String> {
-    debug!("\nArguments vec: {:?}", &arguments);
+    debug!("\nScript arguments vec: {:?}", &arguments);
     let process = Exec::cmd(&arguments.remove(0)).args(&arguments);
     match process.capture() {
         Ok(c) => {


### PR DESCRIPTION
We received a report on discord that the extra arguments passed to the scripting engine got parsed wrong.

![image](https://user-images.githubusercontent.com/44554109/100546019-42448200-325f-11eb-84e1-837281b348fe.png)

This PR fixes the parsing error.
![image](https://user-images.githubusercontent.com/44554109/100546340-3063de80-3261-11eb-97e0-5a42b5ef9e63.png)


Improved `Script to run` feedback to show the final execution format, instead of the execution format found in the scriptfile.
from
![image](https://user-images.githubusercontent.com/44554109/100546118-d7477b00-325f-11eb-945a-1a04b6b58922.png)
to
![image](https://user-images.githubusercontent.com/44554109/100546151-fa722a80-325f-11eb-97c3-b0ae674b1f6c.png)
Also added an extra line to tell the user it may take some time to get results. This till we find a way for constant feedback during runs.

The scanner engine error handling was relying on `ErrorKind::Other` which can cover a lot of different errors. The documentation tells us that the `Other` `ErrorKind` can change and errors that can be found today in that category can move to other categories later. 
![image](https://user-images.githubusercontent.com/44554109/100546480-d6afe400-3261-11eb-8f6a-3c20fde17b55.png)
So matching on the `e.to_string()` with the right error strings feels like a more stable structure. Error messages might get a new category but the string of them will probably stay the same. This PR fixes the possible category change of some errors we filter on as well as simplifying the error handling in general.

I also moved some error handling from inside the `socket_connect` function a level higher into the futures loop. I created a `HashSet` to collect max `self.ips.len() * 1000` error messages, so we can display them in case the user wants to see them. The `HashSet` is fast, I didn't notice any performance degradation, quite the opposit, because there is less error string mathing inside the `socket_connect` function, the scan times improved. 
It's behind the `RUST_LOG=debug` flag, so the default run arguments will not be affected, but it's a great addition to see if there is a connection problem with an ip and the user wants to investigate further.