### PR TITLE
Bump ring dependency to allow for M1 compilation

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -57,7 +57,7 @@ jobs:
             toolchain: stable
             components: clippy
             override: true
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/clippy-check@v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ trust-dns-resolver = { version = "0.19.5", features = ["dns-over-rustls"] }
 anyhow = "1.0.40"
 subprocess = "0.2.6"
 text_placeholder = { version = "0.4", features = ["struct_context"] }
+ring = "0.16.19"
 
 [dev-dependencies]
 wait-timeout = "0.2"


### PR DESCRIPTION
Simple fix which allows RustScan to build on M1 Macs. 

RustScan depends on the `ring` library; version 0.16.15 is automatically used. This version fails to compile on an M1 Mac, but as per https://github.com/briansmith/ring/issues/1163, version 0.16.19 fixes this.

This pins the dependency on `ring` for RustScan to 0.16.19.