### PR TITLE
feat(build): add GitHub Action to make release & build .deb package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: tar-bin
+        run: tar cvf target-bin.tar target/release/rustscan
+      - uses: actions/upload-artifact@v2
+        with:
+          name: target-bin
+          path: target-bin.tar
+
+  build_deb:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: target-bin
+          path: ./
+      - name: untar-bin
+        run: tar xvf target-bin.tar
+      - name: cargo-deb
+        run: |
+          cargo install cargo-deb
+          cargo deb --deb-version ${{ needs.build.outputs.version }}
+      - name: tar-deb
+        run: tar cvf target-deb.tar target/debian/rustscan_${{ needs.build.outputs.version }}_amd64.deb
+      - uses: actions/upload-artifact@v2
+        with:
+          name: target-deb
+          path: target-deb.tar
+
+  make_release:
+    runs-on: ubuntu-latest
+    needs: build_deb
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+  upload_deb:
+    runs-on: ubuntu-latest
+    needs: [build, make_release]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: target-deb
+          path: ./
+      - name: untar-deb
+        run: tar xvf target-deb.tar
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.make_release.outputs.upload_url }}
+          asset_content_type: application/vnd.debian.binary-package
+          asset_path: target/debian/rustscan_${{ needs.build.outputs.version }}_amd64.deb
+          asset_name: rustscan_${{ needs.build.outputs.version }}_amd64.deb


### PR DESCRIPTION
Add a new workflow to, whenever someone adds a new tag to the repo:

- compile `rustscan`;
- create a new GitHub release;
  - this is created as a *draft* release to allow editing/review;
- build a `.deb` file;
- attach the `.deb` to the new release.

There's an [issue](https://github.com/actions/upload-artifact/issues/38) in the `upload-artifact` action which causes the executable-bit to be lost when caching between steps, hence the use of `tar` as a [workaround](https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files).

Relates #83 