### PR TITLE
Improve doc for addresses

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -70,7 +70,7 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
 /// - Discord https://discord.gg/GFrQsGy
 /// - GitHub https://github.com/RustScan/RustScan
 pub struct Opts {
-    /// A list of comma separated CIDRs, IPs, or hosts to be scanned.
+    /// A comma-delimited list or newline-delimited file of separated CIDRs, IPs, or hosts to be scanned.
     #[structopt(short, long, use_delimiter = true)]
     pub addresses: Vec<String>,
 


### PR DESCRIPTION
Improve documentation for addresses CLI arg to make it clear that file parsing of addresses is already supported

(#452)

I, like in the associated issue, did not realise this feature was already implemented from the CLI docs. Want to make this useful feature more discoverable!