### PR TITLE
Update Docker base image from alpine 3.12 to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 RUN cargo build --release
 
-FROM alpine:3.12
+FROM alpine:3.17
 LABEL author="Hydragyrum <https://github.com/Hydragyrum>"
 LABEL author="LeoFVO <https://github.com/LeoFVO>"
 RUN addgroup -S rustscan && \


### PR DESCRIPTION
Alpine Linux v3.12 is end of life about months, the builder base image is alreayd Alpine v3.17, and Alpine v3.17 is the latest stable release with about 2 more years support, should be good to ugprade to it.

Reference: https://alpinelinux.org/releases/