### PR TITLE
:rotating_light: fix linter warnings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -252,7 +252,7 @@ impl Config {
         let config: Config = match toml::from_str(&content) {
             Ok(config) => config,
             Err(e) => {
-                println!("Found {} in configuration file.\nAborting scan.\n", e);
+                println!("Found {e} in configuration file.\nAborting scan.\n");
                 std::process::exit(1);
             }
         };
@@ -263,9 +263,8 @@ impl Config {
 
 /// Constructs default path to config toml
 pub fn default_config_path() -> PathBuf {
-    let mut config_path = match dirs::home_dir() {
-        Some(dir) => dir,
-        None => panic!("Could not infer config file path."),
+    let Some(mut config_path) = dirs::home_dir() else {
+        panic!("Could not infer config file path.");
     };
     config_path.push(".rustscan.toml");
     config_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
         Ok(scripts_to_run) => scripts_to_run,
         Err(e) => {
             warning!(
-                format!("Initiating scripts failed!\n{}", e),
+                format!("Initiating scripts failed!\n{e}"),
                 opts.greppable,
                 opts.accessible
             );
@@ -189,7 +189,7 @@ fn main() {
                     detail!(script_result.to_string(), opts.greppable, opts.accessible);
                 }
                 Err(e) => {
-                    warning!(&format!("Error {}", e), opts.greppable, opts.accessible);
+                    warning!(&format!("Error {e}"), opts.greppable, opts.accessible);
                 }
             }
         }
@@ -233,7 +233,7 @@ fn print_opening(opts: &Opts) {
         .unwrap_or_else(input::default_config_path);
 
     detail!(
-        format!("The config file is expected to be at {:?}", config_path),
+        format!("The config file is expected to be at {config_path:?}"),
         opts.greppable,
         opts.accessible
     );
@@ -262,7 +262,7 @@ fn parse_addresses(input: &Opts) -> Vec<IpAddr> {
 
         if !file_path.is_file() {
             warning!(
-                format!("Host {:?} could not be resolved.", file_path),
+                format!("Host {file_path:?} could not be resolved."),
                 input.greppable,
                 input.accessible
             );
@@ -274,7 +274,7 @@ fn parse_addresses(input: &Opts) -> Vec<IpAddr> {
             ips.extend(x);
         } else {
             warning!(
-                format!("Host {:?} could not be resolved.", file_path),
+                format!("Host {file_path:?} could not be resolved."),
                 input.greppable,
                 input.accessible
             );
@@ -344,7 +344,7 @@ fn adjust_ulimit_size(opts: &Opts) -> u64 {
     if let Some(limit) = opts.ulimit {
         if Resource::NOFILE.set(limit, limit).is_ok() {
             detail!(
-                format!("Automatically increasing ulimit value to {}.", limit),
+                format!("Automatically increasing ulimit value to {limit}."),
                 opts.greppable,
                 opts.accessible
             );

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -125,7 +125,7 @@ impl Scanner {
                     }
                     if !self.greppable {
                         if self.accessible {
-                            println!("Open {}", socket);
+                            println!("Open {socket}");
                         } else {
                             println!("Open {}", socket.to_string().purple());
                         }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -77,9 +77,8 @@ pub fn init_scripts(scripts: ScriptsRequired) -> Result<Vec<ScriptFile>> {
             Ok(scripts_to_run)
         }
         ScriptsRequired::Custom => {
-            let scripts_dir_base = match dirs::home_dir() {
-                Some(dir) => dir,
-                None => return Err(anyhow!("Could not infer scripts path.")),
+            let Some(scripts_dir_base) = dirs::home_dir() else {
+                return Err(anyhow!("Could not infer scripts path."));
             };
             let script_paths = match find_scripts(scripts_dir_base) {
                 Ok(script_paths) => script_paths,
@@ -243,7 +242,7 @@ impl Script {
 #[cfg(not(tarpaulin_include))]
 fn execute_script(mut arguments: Vec<String>) -> Result<String> {
     debug!("\nScript arguments vec: {:?}", &arguments);
-    let process = Exec::cmd(&arguments.remove(0)).args(&arguments);
+    let process = Exec::cmd(arguments.remove(0)).args(&arguments);
     match process.capture() {
         Ok(c) => {
             let es = match c.exit_status {
@@ -335,9 +334,8 @@ pub struct ScriptConfig {
 #[cfg(not(tarpaulin_include))]
 impl ScriptConfig {
     pub fn read_config() -> Result<ScriptConfig> {
-        let mut home_dir = match dirs::home_dir() {
-            Some(dir) => dir,
-            None => return Err(anyhow!("Could not infer ScriptConfig path.")),
+        let Some(mut home_dir) = dirs::home_dir() else {
+            return Err(anyhow!("Could not infer ScriptConfig path."));
         };
         home_dir.push(".rustscan_scripts.toml");
 


### PR DESCRIPTION
referring to https://github.com/RustScan/RustScan/actions/runs/4716508271/jobs/8364299022
these linting warnings breaks the cicd