### PR TITLE
Fix clippy lint issues for CI/CD pipeline

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -228,6 +228,7 @@ pub struct Config {
 }
 
 #[cfg(not(tarpaulin_include))]
+#[allow(clippy::doc_link_with_quotes)]
 impl Config {
     /// Reads the configuration file with TOML format and parses it into a
     /// Config struct.

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ fn main() {
 }
 
 /// Prints the opening title of RustScan
-#[allow(clippy::items_after_statements)]
+#[allow(clippy::items_after_statements, clippy::needless_raw_string_hashes)]
 fn print_opening(opts: &Opts) {
     debug!("Printing opening");
     let s = format!(

--- a/src/scanner/socket_iterator.rs
+++ b/src/scanner/socket_iterator.rs
@@ -29,6 +29,7 @@ impl<'s> SocketIterator<'s> {
     }
 }
 
+#[allow(clippy::doc_link_with_quotes)]
 impl<'s> Iterator for SocketIterator<'s> {
     type Item = SocketAddr;
 


### PR DESCRIPTION
Fix clippy lint issue to let CI/CD checks run. The change has no effect on the code, just on the clippy warnings.