### PR TITLE
Fix markdown-link-checker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-    branches: [ 'main']
+    branches: ['master']
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-    branches: [ "main"]
+    branches: [ 'main']
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,15 +7,6 @@ on:
     branches: [ 'main']
   release:
     types: [published]
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'Dockerfile'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'contributing.Dockerfile'
-      - '.github/workflows/docker.yml'
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,25 +22,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          password: ${{ secrets.DOCKER_PASSWORD }}
           username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: rustscan/rustscan
-          flavor: latest=true
+          images: cmnatic/rustscan
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
-          push: ${{ contains(fromJson('["push", "release"]'), github.event_name) }} # Publish to docker registry only on push event or new release.
+          file: ./Dockerfile
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches: [ "main"]
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -16,3 +16,4 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
+        config-file: './.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,14 @@
+{
+    "_comment": "Config for markdown-link-check. Resolves issue #540.",
+    "ignorePatterns": [
+      {
+        "pattern": "^https://github.com/RustScan/RustScan/workflows/Continuous%20integration/badge.svg"
+      },
+      {
+        "pattern": "^https://crates.io/crates/rustscan/"
+      },
+      {
+        "pattern": "^https://bees.substack.com/p/making-hacking-accessible"
+      }
+    ]
+  }

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo build --release
 
 FROM alpine:3.17
 LABEL author="Hydragyrum <https://github.com/Hydragyrum>"
-LABEL author="LeoFVOtesttest <https://github.com/LeoFVO>"
+LABEL author="LeoFVOtesttestteaasstestest <https://github.com/LeoFVO>"
 RUN addgroup -S rustscan && \
     adduser -S -G rustscan rustscan && \
     ulimit -n 100000 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo build --release
 
 FROM alpine:3.17
 LABEL author="Hydragyrum <https://github.com/Hydragyrum>"
-LABEL author="LeoFVOtesttestteaasstestest <https://github.com/LeoFVO>"
+LABEL author="LeoFVOcmnaticcmantic <https://github.com/LeoFVO>"
 RUN addgroup -S rustscan && \
     adduser -S -G rustscan rustscan && \
     ulimit -n 100000 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo build --release
 
 FROM alpine:3.17
 LABEL author="Hydragyrum <https://github.com/Hydragyrum>"
-LABEL author="LeoFVO <https://github.com/LeoFVO>"
+LABEL author="LeoFVOtesttest <https://github.com/LeoFVO>"
 RUN addgroup -S rustscan && \
     adduser -S -G rustscan rustscan && \
     ulimit -n 100000 && \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ![fast][speed-1]
 
-The Modern Port Scanner. **Find ports quickly (3 seconds at its fastest)**. Run scripts through our scripting engine (Python, Lua, Shell supported).
+The Modern Port Scanner. **Find ports quickly (3 seconds at its fastest)**. Run scripts through our scripting engine (Python, Lua, Shell supported)tessssst.
 
 # ✨ Features
 


### PR DESCRIPTION
For https://github.com/RustScan/RustScan/issues/540

Added a configuration file that tells MLC to ignore the URLs in .github\workflows\mlc_config.json as MLC is falsely reporting these as dead, and blocking CICD

![image](https://github.com/RustScan/RustScan/assets/4163116/c1699a02-baab-4ec6-a58d-2c90afc584e7)
