### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Set Git config. (windows only)
-        if: matrix.build == 'x86_64-windows' # Windows is missing some dependencies
+        if: contains(matrix.build, 'windows') # Windows is missing some dependencies
         run: |
           git config --global pack.windowMemory "100m"
           git config --global pack.packSizeLimit "100m"
@@ -68,7 +68,7 @@ jobs:
           git config --global pack.deltaCacheSize "512m"
 
       - name: Install python 3.10 for windows
-        if: matrix.build == 'x86_64-windows' # Windows is missing some dependencies
+        if: contains(matrix.build, 'windows') # Windows is missing some dependencies
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -101,7 +101,7 @@ jobs:
           args: --release --locked --target ${{ matrix.target }}
 
       - name: Calculate tag name
-        if: matrix.build == 'x86_64-linux'
+        if: contains(matrix.build, 'linux')
         run: |
           name=dev
           if [[ ${GITHUB_REF} =~ refs/tags/[0-9]+.[0-9]+.[0-9]+ ]]; then
@@ -112,7 +112,7 @@ jobs:
         id: tagname
 
       - name: Build deb package (linux only)
-        if: matrix.build == 'x86_64-linux'
+        if: contains(matrix.build, 'linux')
         run: |
           cargo install cargo-deb
           cargo deb --target ${{ matrix.target }} --deb-version ${TAG}
@@ -121,13 +121,13 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          if [[ "${{ matrix.build }}" =~ "windows" ]]; then
             cp "target/${{ matrix.target }}/release/$BIN_NAME.exe" "dist/"
           else
             cp "target/${{ matrix.target }}/release/$BIN_NAME" "dist/"
           fi
 
-          if [ "${{ matrix.build }}" = "x86_64-linux" ]; then
+          if [[ "${{ matrix.build }}" =~ "linux" ]]; then
             cp "target/${{ matrix.target }}/debian/rustscan_${TAG}_amd64.deb" "dist/"
           fi
       - uses: actions/upload-artifact@v2.2.4
@@ -181,7 +181,7 @@ jobs:
               mv bins-$platform/$BIN_NAME$exe tmp/$pkgname
               chmod +x tmp/$pkgname/$BIN_NAME$exe
 
-              if [[ $platform == "x86_64-linux" ]]; then
+              if [[ $platform =~ "linux" ]]; then
                   mv "bins-$platform/rustscan_${TAG}_amd64.deb" dist/
               fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - master
@@ -104,8 +104,8 @@ jobs:
         if: matrix.build == 'x86_64-linux'
         run: |
           name=dev
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            name=${GITHUB_REF:10}
+          if [[ ${GITHUB_REF} =~ refs/tags/[0-9]+.[0-9]+.[0-9]+ ]]; then
+            name=${GITHUB_REF#refs/tags/}
           fi
           echo ::set-output name=val::$name
           echo TAG=$name >> $GITHUB_ENV
@@ -155,8 +155,8 @@ jobs:
       - name: Calculate tag name
         run: |
           name=dev
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            name=${GITHUB_REF:10}
+          if [[ ${GITHUB_REF} =~ refs/tags/[0-9]+.[0-9]+.[0-9]+ ]]; then
+            name=${GITHUB_REF#refs/tags/}
           fi
           echo ::set-output name=val::$name
           echo TAG=$name >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         #   target: i686-pc-windows-msvc
 
     steps:
-      - name: Strip release binary (linux and macos)
+      - name: Set Git config. (windows only)
         if: matrix.build == 'x86_64-windows' # Windows is missing some dependencies
         run: |
           git config --global pack.windowMemory "100m"
@@ -99,19 +99,6 @@ jobs:
           use-cross: ${{ matrix.cross }}
           command: build
           args: --release --locked --target ${{ matrix.target }}
-
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos'
-        run: strip "target/${{ matrix.target }}/release/$BIN_NAME"
-
-      - name: Strip release binary (arm)
-        if: matrix.build == 'aarch64-linux'
-        run: |
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:${{ matrix.target }} \
-            aarch64-linux-gnu-strip \
-            /target/${{ matrix.target }}/release/$BIN_NAME
 
       - name: Calculate tag name
         if: matrix.build == 'x86_64-linux'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ section = "rust"
 [profile.release]
 lto = true
 panic = 'abort'
+strip = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]


### PR DESCRIPTION
Apologies if this is excessive but following #427, there are a few things I noticed:

1. `Cargo.toml` now supports [`strip`](https://doc.rust-lang.org/cargo/reference/profiles.html#strip) which I _think_ should replace the explicit `strip` steps in the release workflow, unless there's any other reason they're not quite identical…?
2. the trigger for the release workflow includes a tag with a `v` prefix. However, no existing tags/releases have that prefix; I've removed it and updated the workflow accordingly.
    - the `docker.yml` has the same trigger—if the above holds true, should that be updated to match?
4. as kinda touched upon in #427, I've made the OS/build checks in each step more generic (i.e. matching `linux`, not `x86_64-linux`) so if future architectures are added, the workflow should accommodate them.

Let me know if I've misread anything or any of the above isn't required/desired.