### PR TITLE
Update Docker Runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,7 @@ fn parse_addresses(input: &Opts) -> Vec<IpAddr> {
     ips
 }
 
-/// Given a string, parse it as an host, IP address, or CIDR.
+/// Given a string, parse it as a host, IP address, or CIDR.
 /// This allows us to pass files as hosts or cidr or IPs easily
 /// Call this every time you have a possible IP_or_host
 fn parse_address(address: &str, resolver: &Resolver) -> Vec<IpAddr> {


### PR DESCRIPTION
This PR upgrades the DockerHub login job from `v2` to `v3`, as per the workflow's [repository](https://github.com/docker/login-action?tab=readme-ov-file#docker-hub), it recommends using a personal access token and not account password. This should hopefully fix the check failing on PRs (i.e. #559).

I've updated the repository secrets to reference `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` and the `docker.yml` appropriately.

The modification to `main.rs` is just resolving a typo to force the action to be ran.