### PR TITLE
build: update Docker workflow trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types: [published]
   pull_request:


### PR DESCRIPTION
as requested in #559, remove the `v` prefix from the triggering tag for the Docker workflow, to match the standard tagging pattern.