### PR TITLE
refactor: make RustScan additionally a library

### DIFF
--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -1,15 +1,18 @@
 //! # Usage
-//! ```
+//!
+//! ```rust
 //! // Initiate Benchmark vector
+//! # use rustscan::benchmark::{Benchmark, NamedTimer};
+//! # use log::info;
 //! let mut bm = Benchmark::init();
 //! // Start named timer with name
 //! let mut example_bench = NamedTimer::start("Example Bench");
 //! // Stop named timer
-//! example_bench.stop();
+//! example_bench.end();
 //! // Add named timer to Benchmarks
 //! bm.push(example_bench);
 //! // Print Benchmark Summary
-//! info!({}, bm.summary());
+//! info!("{}", bm.summary());
 //! ```
 use std::time::Instant;
 

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -1,3 +1,5 @@
+//! Provides functionality to capture timing information for scans.
+//!
 //! # Usage
 //!
 //! ```rust

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+//! Provides a means to read, parse and hold configuration options for scans.
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::fs;

--- a/src/input.rs
+++ b/src/input.rs
@@ -211,6 +211,29 @@ impl Opts {
     }
 }
 
+impl Default for Opts {
+    fn default() -> Self {
+        Self {
+            addresses: vec![],
+            ports: None,
+            range: None,
+            greppable: true,
+            batch_size: 0,
+            timeout: 0,
+            tries: 0,
+            ulimit: None,
+            command: vec![],
+            accessible: false,
+            scan_order: ScanOrder::Serial,
+            no_config: true,
+            top: false,
+            scripts: ScriptsRequired::Default,
+            config_path: None,
+            exclude_ports: None,
+        }
+    }
+}
+
 /// Struct used to deserialize the options specified within our config file.
 /// These will be further merged with our command line arguments in order to
 /// generate the final Opts struct.
@@ -295,29 +318,6 @@ mod tests {
                 accessible: Some(true),
                 scan_order: Some(ScanOrder::Random),
                 scripts: None,
-                exclude_ports: None,
-            }
-        }
-    }
-
-    impl Opts {
-        pub fn default() -> Self {
-            Self {
-                addresses: vec![],
-                ports: None,
-                range: None,
-                greppable: true,
-                batch_size: 0,
-                timeout: 0,
-                tries: 0,
-                ulimit: None,
-                command: vec![],
-                accessible: false,
-                scan_order: ScanOrder::Serial,
-                no_config: true,
-                top: false,
-                scripts: ScriptsRequired::Default,
-                config_path: None,
                 exclude_ports: None,
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod tui;
+
+pub mod input;
+
+pub mod scanner;
+
+pub mod port_strategy;
+
+pub mod benchmark;
+
+pub mod scripts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,45 @@
+//! This crate exposes the internal functionality of the
+//! [RustScan](https://rustscan.github.io/RustScan) port scanner.
+//!
+//! ## Example: perform a scan against localhost
+//!
+//! The core scanning behaviour is managed by
+//! [`Scanner`](crate::scanner::Scanner) which in turn requires a
+//! [`PortStrategy`](crate::port_strategy::PortStrategy):
+//!
+//! ```rust
+//! use async_std::task::block_on;
+//! use std::{net::IpAddr, time::Duration};
+//!
+//! use rustscan::input::{PortRange, ScanOrder};
+//! use rustscan::port_strategy::PortStrategy;
+//! use rustscan::scanner::Scanner;
+//!
+//! fn main() {
+//!     let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
+//!     let range = PortRange {
+//!         start: 1,
+//!         end: 1_000,
+//!     };
+//!     let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+//!     let scanner = Scanner::new(
+//!         &addrs,
+//!         10,
+//!         Duration::from_millis(100),
+//!         1,
+//!         true,
+//!         strategy,
+//!         true,
+//!         vec![9000],
+//!     );
+//!
+//!     let scan_result = block_on(scanner.run());
+//!
+//!     println!("{:?}", scan_result);
+//! }
+//! ```
+#![allow(clippy::needless_doctest_main)]
+
 pub mod tui;
 
 pub mod input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,22 +2,12 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::doc_markdown, clippy::if_not_else, clippy::non_ascii_literal)]
 
-mod tui;
-
-mod input;
-use input::{Config, Opts, PortRange, ScanOrder, ScriptsRequired};
-
-mod scanner;
-use scanner::Scanner;
-
-mod port_strategy;
-use port_strategy::PortStrategy;
-
-mod benchmark;
-use benchmark::{Benchmark, NamedTimer};
-
-mod scripts;
-use scripts::{init_scripts, Script, ScriptFile};
+use rustscan::benchmark::{Benchmark, NamedTimer};
+use rustscan::input::{self, Config, Opts, ScriptsRequired};
+use rustscan::port_strategy::PortStrategy;
+use rustscan::scanner::Scanner;
+use rustscan::scripts::{init_scripts, Script, ScriptFile};
+use rustscan::{detail, funny_opening, output, warning};
 
 use cidr_utils::cidr::IpCidr;
 use colorful::{Color, Colorful};
@@ -407,9 +397,8 @@ fn infer_batch_size(opts: &Opts, ulimit: u64) -> u16 {
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    use crate::{adjust_ulimit_size, infer_batch_size};
-
-    use crate::{parse_addresses, print_opening, Opts};
+    use super::{adjust_ulimit_size, infer_batch_size};
+    use super::{parse_addresses, print_opening, Opts};
     use std::net::Ipv4Addr;
 
     #[test]

--- a/src/port_strategy/mod.rs
+++ b/src/port_strategy/mod.rs
@@ -1,3 +1,4 @@
+//! Provides a means to hold configuration options specifically for port scanning.
 mod range_iterator;
 use crate::input::{PortRange, ScanOrder};
 use rand::seq::SliceRandom;

--- a/src/port_strategy/mod.rs
+++ b/src/port_strategy/mod.rs
@@ -1,5 +1,5 @@
 mod range_iterator;
-use super::{PortRange, ScanOrder};
+use crate::input::{PortRange, ScanOrder};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use range_iterator::RangeIterator;
@@ -97,7 +97,7 @@ impl RangeOrder for RandomRange {
 #[cfg(test)]
 mod tests {
     use super::PortStrategy;
-    use crate::{PortRange, ScanOrder};
+    use crate::input::{PortRange, ScanOrder};
 
     #[test]
     fn serial_strategy_with_range() {

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,3 +1,4 @@
+//! Core functionality for actual scanning behaviour.
 use crate::port_strategy::PortStrategy;
 use log::debug;
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -64,7 +64,7 @@ impl Scanner {
 
     /// Runs scan_range with chunk sizes
     /// If you want to run RustScan normally, this is the entry point used
-    /// Returns all open ports as Vec<u16>
+    /// Returns all open ports as `Vec<u16>`
     /// Added by wasuaje - 01/26/2024:
     ///    Filtering port against exclude port list
     pub async fn run(&self) -> Vec<SocketAddr> {
@@ -116,14 +116,16 @@ impl Scanner {
 
     /// Given a socket, scan it self.tries times.
     /// Turns the address into a SocketAddr
-    /// Deals with the <result> type
+    /// Deals with the `<result>` type
     /// If it experiences error ErrorKind::Other then too many files are open and it Panics!
     /// Else any other error, it returns the error in Result as a string
     /// If no errors occur, it returns the port number in Result to signify the port is open.
     /// This function mainly deals with the logic of Results handling.
     /// # Example
     ///
-    ///     self.scan_socket(socket)
+    /// ```compile_fail
+    /// scanner.scan_socket(socket)
+    /// ```
     ///
     /// Note: `self` must contain `self.ip`.
     async fn scan_socket(&self, socket: SocketAddr) -> io::Result<SocketAddr> {
@@ -169,13 +171,16 @@ impl Scanner {
     /// Performs the connection to the socket with timeout
     /// # Example
     ///
-    ///     let port: u16 = 80
-    ///     // ip is an IpAddr type
-    ///     let ip = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-    ///     let socket = SocketAddr::new(ip, port);
-    ///     self.connect(socket)
-    ///     // returns Result which is either Ok(stream) for port is open, or Er for port is closed.
-    ///     // Timeout occurs after self.timeout seconds
+    /// ```compile_fail
+    /// # use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+    /// let port: u16 = 80;
+    /// // ip is an IpAddr type
+    /// let ip = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    /// let socket = SocketAddr::new(ip, port);
+    /// scanner.connect(socket);
+    /// // returns Result which is either Ok(stream) for port is open, or Er for port is closed.
+    /// // Timeout occurs after self.timeout seconds
+    /// ```
     ///
     async fn connect(&self, socket: SocketAddr) -> io::Result<TcpStream> {
         let stream = io::timeout(

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,4 +1,5 @@
-use super::PortStrategy;
+use crate::port_strategy::PortStrategy;
+use log::debug;
 
 mod socket_iterator;
 use socket_iterator::SocketIterator;
@@ -189,7 +190,7 @@ impl Scanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PortRange, ScanOrder};
+    use crate::input::{PortRange, ScanOrder};
     use async_std::task::block_on;
     use std::{net::IpAddr, time::Duration};
 

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -47,6 +47,7 @@
 
 use crate::input::ScriptsRequired;
 use anyhow::{anyhow, Result};
+use log::debug;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::convert::TryInto;

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,47 +1,77 @@
 //! Scripting Engine to run scripts based on tags.
+//!
 //! This module serves to filter and run the scripts selected by the user.
 //!
 //! A new commandline and configuration file option was added.
 //!
-//! --scripts
+//! ## `--scripts`
 //!
-//!   default
-//!     This is the default behavior, like as it was from the beginning of RustScan.
-//!     The user do not have to chose anything for this. This is the only script embedded in RustScan running as default.
+//! ### `default`
 //!
-//!   none
-//!     The user have to use the --scripts none commandline argument or scripts = "none" in the config file.
-//!     None of the scripts will run, this replaces the removed --no-nmap option.
+//! This is the default behavior, like as it was from the beginning of RustScan.
 //!
-//!   custom
-//!     The user have to use the --scripts custom commandline argument or scripts = "custom" in the config file.
-//!     Rustscan will look for the script configuration file in the user's home dir: home_dir/.rustscan_scripts.toml
-//!     The config file have 3 optional fields, tag, developer and port. Just the tag field will be used forther in the process.
-//!     RustScan will also look for available scripts in the user's home dir: home_dir/.rustscan_scripts
-//!     and will try to read all the files, and parse them into a vector of ScriptFiles.
-//!     Filtering on tags means the tags found in the rustscan_scripts.toml file will also have to be present in the Scriptfile,
-//!     otherwise the script will not be selected.
-//!     All of the rustscan_script.toml tags have to be present at minimum in a Scriptfile to get selected, but can be also more.
+//! The user do not have to chose anything for this. This is the only script
+//! embedded in RustScan running as default.
+//!
+//! ### `none`
+//!
+//! The user have to use the `--scripts none` commandline argument or `scripts =
+//! "none"` in the config file.
+//!
+//! None of the scripts will run, this replaces the removed `--no-nmap` option.
+//!
+//! ### `custom`
+//!
+//! The user have to use the `--scripts custom` commandline argument or
+//! `scripts = "custom"` in the config file.
+//!
+//! RustScan will look for the script configuration file in the user's home
+//! dir: `home_dir/.rustscan_scripts.toml`
+//!
+//! The config file have 3 optional fields: `tag`, `developer` and `port`. Just
+//! the `tag` field will be used forther in the process.
+//!
+//! RustScan will also look for available scripts in the user's home dir:
+//! `home_dir/.rustscan_scripts` and will try to read all the files, and parse
+//! them into a vector of [`ScriptFile`].
+//!
+//! Filtering on tags means the tags found in the `rustscan_scripts.toml` file
+//! will also have to be present in the [`ScriptFile`], otherwise the script
+//! will not be selected.
+//!
+//! All of the `rustscan_script.toml` tags have to be present at minimum in a
+//! [`ScriptFile`] to get selected, but can be also more.
 //!
 //! Config file example:
-//! fixtures/test_rustscan_scripts.toml
+//!
+//! - `fixtures/test_rustscan_scripts.toml`
 //!
 //! Script file examples:
-//! fixtures/test_script.py
-//! fixtures/test_script.pl
-//! fixtures/test_script.sh
-//! fixtures/test_script.txt
 //!
-//! call_format in script files can be of 2 variants.
-//! One is where all of the possible tags {{script}} {{ip}} {{port}} are there.
-//!     The {{script}} part will be replaced with the scriptfile full path gathered while parsing available scripts.
-//!     The {{ip}} part will be replaced with the ip we got from the scan.
-//!     The {{port}} part will be reaplced with the ports separated with the ports_separator found in the script file
+//! - `fixtures/test_script.py`
+//! - `fixtures/test_script.pl`
+//! - `fixtures/test_script.sh`
+//! - `fixtures/test_script.txt`
 //!
-//! And when there is only {{ip}} and {{port}} is in the format, only those will be replaced with the arguments from the scan.
-//! This makes it easy to run a system installed command like nmap, and give any kind of arguments to it.
+//! `call_format` in script files can be of 2 variants:
 //!
-//! If the format is different, the script will be silently discarded and will not run. With the Debug option it's possible to see where it goes wrong.
+//! One is where all of the possible tags `{{script}}`, `{{ip}}` and `{{port}}`
+//! are there.
+//!
+//! - The `{{script}}` part will be replaced with the scriptfile full path
+//!   gathered while parsing available scripts.
+//! - The `{{ip}}` part will be replaced with the ip we got from the scan.
+//! - The `{{port}}` part will be reaplced with the ports separated with the
+//!   `ports_separator` found in the script file
+//!
+//! And when there is only `{{ip}}` and `{{port}}` is in the format, only those
+//! will be replaced with the arguments from the scan.
+//!
+//! This makes it easy to run a system installed command like `nmap`, and give
+//! any kind of arguments to it.
+//!
+//! If the format is different, the script will be silently discarded and will
+//! not run. With the `Debug` option it's possible to see where it goes wrong.
 
 #![allow(clippy::module_name_repetitions)]
 

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -5,23 +5,23 @@
 //!
 //! --scripts
 //!
-//!      default
-//!          This is the default behavior, like as it was from the beginning of RustScan.
-//!          The user do not have to chose anything for this. This is the only script embedded in RustScan running as default.
+//!   default
+//!     This is the default behavior, like as it was from the beginning of RustScan.
+//!     The user do not have to chose anything for this. This is the only script embedded in RustScan running as default.
 //!
-//!      none
-//!          The user have to use the --scripts none commandline argument or scripts = "none" in the config file.
-//!          None of the scripts will run, this replaces the removed --no-nmap option.
+//!   none
+//!     The user have to use the --scripts none commandline argument or scripts = "none" in the config file.
+//!     None of the scripts will run, this replaces the removed --no-nmap option.
 //!
-//!      custom
-//!          The user have to use the --scripts custom commandline argument or scripts = "custom" in the config file.
-//!          Rustscan will look for the script configuration file in the user's home dir: home_dir/.rustscan_scripts.toml
-//!          The config file have 3 optional fields, tag, developer and port. Just the tag field will be used forther in the process.
-//!          RustScan will also look for available scripts in the user's home dir: home_dir/.rustscan_scripts
-//!          and will try to read all the files, and parse them into a vector of ScriptFiles.
-//!          Filtering on tags means the tags found in the rustscan_scripts.toml file will also have to be present in the Scriptfile,
-//!          otherwise the script will not be selected.
-//!          All of the rustscan_script.toml tags have to be present at minimum in a Scriptfile to get selected, but can be also more.
+//!   custom
+//!     The user have to use the --scripts custom commandline argument or scripts = "custom" in the config file.
+//!     Rustscan will look for the script configuration file in the user's home dir: home_dir/.rustscan_scripts.toml
+//!     The config file have 3 optional fields, tag, developer and port. Just the tag field will be used forther in the process.
+//!     RustScan will also look for available scripts in the user's home dir: home_dir/.rustscan_scripts
+//!     and will try to read all the files, and parse them into a vector of ScriptFiles.
+//!     Filtering on tags means the tags found in the rustscan_scripts.toml file will also have to be present in the Scriptfile,
+//!     otherwise the script will not be selected.
+//!     All of the rustscan_script.toml tags have to be present at minimum in a Scriptfile to get selected, but can be also more.
 //!
 //! Config file example:
 //! fixtures/test_rustscan_scripts.toml

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,5 @@
+//! Utilities for terminal output during scanning.
+
 /// Terminal User Interface Module for RustScan
 /// Defines macros to use
 #[macro_export]


### PR DESCRIPTION
- add `lib.rs` (permitted as per [_Packages and Crates_](https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html)).
- refactor `main.rs` to reference the library.
- update module references as required.

relates #497

By way of example, configuring a new binary project which references this crate:

```toml
[dependencies]
async-std = "^1.7"
rustscan = { path = "/home/rust/git/RustScan" }
```

…allows `rustscan` to be referenced as a library:

```rust
use async_std::task::block_on;
use std::{net::IpAddr, time::Duration};

use rustscan::input::{PortRange, ScanOrder};
use rustscan::port_strategy::PortStrategy;
use rustscan::scanner::Scanner;

fn main() {
    let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
    let range = PortRange {
        start: 1,
        end: 1_000,
    };
    let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
    let scanner = Scanner::new(
        &addrs,
        10,
        Duration::from_millis(100),
        1,
        true,
        strategy,
        true,
        vec![9000],
    );

    let scan_result = block_on(scanner.run());

    println!("{:?}", scan_result);
}
```