### PR TITLE
Docker Image Checks Rework

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,14 +3,14 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - 'master'
+      - 'master' # push on merge/commit to master to create a latest tag
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types: [published]
   pull_request:
     branches:
-      - master
+      - master # run part as PR checks, but the image will not be published on DockerHub (as this will tag it as say rustscan/rustscan:pr-400)
     paths:
       - 'Dockerfile'
       - 'Cargo.toml'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: cmnatic/githubtest
+          images: rustscan/rustscan
           flavor: latest=true
 
       - name: Build and push Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ name: Publish Docker image
 
 on:
   push:
+    branches:
+      - 'master'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   release:
@@ -25,21 +27,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          password: ${{ secrets.DOCKERHUB_USERNAME }}
-          username: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: rustscan/rustscan
+          images: cmnatic/githubtest
           flavor: latest=true
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
           push: ${{ contains(fromJson('["push", "release"]'), github.event_name) }} # Publish to docker registry only on push event or new release.


### PR DESCRIPTION
Hello!

I have modified the docker.yml GitHub action that is used to build and publish the Dockerfile to DockerHub. For quite a while, the check would fail on PRs and releases. This is likely due to the action changing/DockerHub API changing since we implemented the workflow on our end.

I have now used a different action and configured the docker.yml workflow to:

1) Run when a new release is made; this will tag it as `rustscan/rustscan:1.11.11` on DockerHub, for example
2) It now successfully runs when a PR is made. However, the Dockerfile is only built, and isn't actually published. Otherwise, this means our DockerHub will be full of tags such as `rustscan/rustscan:pr-400`, but building it is important for CI/CD purposes, and the check will fail if it fails to compile RustScan.

3) It will now run when a merge or commit is made to the `master` branch, this will result in a `latest` tag being published to DockerHub, so people can try out new features/updates without having to wait for an official release.

4) Use a DockerHub access token (repo secret) to login to DockerHub 

![image](https://github.com/RustScan/RustScan/assets/4163116/1d4674f8-a76a-4a7e-b9a0-84ec29afb04d)

![image](https://github.com/RustScan/RustScan/assets/4163116/11d765ed-715c-4ceb-a15e-4c018d21f2fc)


I've tested it on my end with a demo repository and new DockerHub repo: `cmnatic/githubtest`, but we will need to see how it works out for rustscan/rustscan :)

TODO: figure out how we can determine "what is stable" to create a "stable" tag for #533. Maybe this is just a re-tag of the latest release.