### PR TITLE
 feat(cli): add custom dns resolver option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pemfile",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "rustls",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1480,7 @@ dependencies = [
  "env_logger",
  "futures",
  "gcd",
+ "hickory-resolver",
  "itertools",
  "log",
  "rand 0.7.3",
@@ -1440,7 +1491,6 @@ dependencies = [
  "subprocess",
  "text_placeholder",
  "toml",
- "trust-dns-resolver",
  "wait-timeout",
 ]
 
@@ -1756,59 +1806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "rustls",
- "rustls-pemfile",
- "rustls-webpki",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "rustls",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tracing",
- "trust-dns-proto",
- "webpki-roots",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,12 +1981,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = "1.0.124"
 serde_derive = "1.0.116"
 cidr-utils = "0.5.1"
 itertools = "0.9.0"
-trust-dns-resolver = { version = "0.23.2", features = ["dns-over-rustls"] }
+hickory-resolver = { version = "0.24.0", features = ["dns-over-rustls"] }
 anyhow = "1.0.40"
 subprocess = "0.2.6"
 text_placeholder = { version = "0.5", features = ["struct_context"] }

--- a/src/address.rs
+++ b/src/address.rs
@@ -34,18 +34,15 @@ pub fn parse_addresses(input: &Opts) -> Vec<IpAddr> {
     let mut backup_resolver =
         Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts::default()).unwrap();
 
-    if input.resolver.ne("") {
-        let resolver_ips = if let Ok(r) = read_resolver_from_file(input.resolver.as_str()) {
+    if let Some(resolver) = &input.resolver {
+        let resolver_ips = if let Ok(r) = read_resolver_from_file(resolver) {
             r
         } else {
             // Get resolvers from the comma-delimited list string
-            let mut r = Vec::new();
-            input.resolver.split(',').for_each(|item| {
-                if let Ok(ip) = IpAddr::from_str(item) {
-                    r.push(ip)
-                }
-            });
-            r
+            resolver
+                .split(',')
+                .filter_map(|r| IpAddr::from_str(r).ok())
+                .collect::<Vec<_>>()
         };
         let mut rc = ResolverConfig::new();
         for ip in resolver_ips {

--- a/src/input.rs
+++ b/src/input.rs
@@ -100,7 +100,7 @@ pub struct Opts {
     #[structopt(long)]
     pub accessible: bool,
 
-    /// A comma-delimited list or file of dns resolvers
+    /// A comma-delimited list or file of DNS resolvers.
     #[structopt(long)]
     pub resolver: Option<String>,
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -100,6 +100,10 @@ pub struct Opts {
     #[structopt(long)]
     pub accessible: bool,
 
+    /// A comma-delimited list or file of dns resolvers
+    #[structopt(long, default_value = "")]
+    pub resolver: String,
+
     /// The batch size for port scanning, it increases or slows the speed of
     /// scanning. Depends on the open file limit of your OS.  If you do 65535
     /// it will do every port at the same time. Although, your OS may not
@@ -225,6 +229,7 @@ impl Default for Opts {
             ulimit: None,
             command: vec![],
             accessible: false,
+            resolver: String::from(""),
             scan_order: ScanOrder::Serial,
             no_config: true,
             top: false,

--- a/src/input.rs
+++ b/src/input.rs
@@ -212,7 +212,7 @@ impl Opts {
             self.ports = Some(ports);
         }
 
-        merge_optional!(range, ulimit, exclude_ports);
+        merge_optional!(range, resolver, ulimit, exclude_ports);
     }
 }
 
@@ -255,6 +255,7 @@ pub struct Config {
     timeout: Option<u32>,
     tries: Option<u8>,
     ulimit: Option<u64>,
+    resolver: Option<String>,
     scan_order: Option<ScanOrder>,
     command: Option<Vec<String>>,
     scripts: Option<ScriptsRequired>,
@@ -322,6 +323,7 @@ mod tests {
                 ulimit: None,
                 command: Some(vec!["-A".to_owned()]),
                 accessible: Some(true),
+                resolver: None,
                 scan_order: Some(ScanOrder::Random),
                 scripts: None,
                 exclude_ports: None,
@@ -369,10 +371,12 @@ mod tests {
             end: 1_000,
         });
         config.ulimit = Some(1_000);
+        config.resolver = Some("1.1.1.1".to_owned());
 
         opts.merge_optional(&config);
 
         assert_eq!(opts.range, config.range);
         assert_eq!(opts.ulimit, config.ulimit);
+        assert_eq!(opts.resolver, config.resolver);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -101,8 +101,8 @@ pub struct Opts {
     pub accessible: bool,
 
     /// A comma-delimited list or file of dns resolvers
-    #[structopt(long, default_value = "")]
-    pub resolver: String,
+    #[structopt(long)]
+    pub resolver: Option<String>,
 
     /// The batch size for port scanning, it increases or slows the speed of
     /// scanning. Depends on the open file limit of your OS.  If you do 65535
@@ -229,7 +229,7 @@ impl Default for Opts {
             ulimit: None,
             command: vec![],
             accessible: false,
-            resolver: String::from(""),
+            resolver: None,
             scan_order: ScanOrder::Serial,
             no_config: true,
             top: false,


### PR DESCRIPTION
Note: this extends #531 (to which I don't have write-access) but retains all the commits therein (all credit to @khanhnt2).

relates #531

As discussed on that PR:

- fixed the linting issues;
- added some tests (not easy as `Resolver` hides a lot of its internal fields so validating the exact type built doesn't appear to be straightforward).
- updated the derivation to be:
    - if `--resolver` is passed or `resolver` is set in config:
        - assume the value is a file and read that;
        - if not, assume it's comma-separated IP addresses;
    - if no argument is passed:
        - [derive from the system config.](https://github.com/hickory-dns/hickory-dns/blob/main/crates/resolver/src/resolver.rs#L113);
        - if that fails, fall back to the previous CloudFlare behvaiour.