### PR TITLE
refactor: remove structopt in favour of clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,17 +368,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags 1.3.2",
+ "clap_derive",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -457,7 +481,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -728,6 +752,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -740,15 +770,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -856,6 +877,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1098,6 +1129,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking"
@@ -1427,6 +1464,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "cidr-utils",
+ "clap",
  "colored",
  "colorful",
  "dirs",
@@ -1440,7 +1478,6 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_derive",
- "structopt",
  "subprocess",
  "text_placeholder",
  "toml",
@@ -1552,33 +1589,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subprocess"
@@ -1613,6 +1626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "text_placeholder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,12 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -1720,7 +1739,7 @@ version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1780,18 +1799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,12 +1826,6 @@ name = "value-bag"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1950,6 +1951,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -859,6 +865,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1101,6 +1117,27 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parameterized"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194bf497674dda552d4f1bd24d325f828f425876c9d522fcb1810cd527e0bd4e"
+dependencies = [
+ "parameterized-macro",
+]
+
+[[package]]
+name = "parameterized-macro"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1374bca5edab7a317c4ffbc9df1e239ceb7dcf5426b6b403474408442a9777ac"
+dependencies = [
+ "indexmap 1.9.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking"
@@ -1416,6 +1453,7 @@ dependencies = [
  "hickory-resolver",
  "itertools",
  "log",
+ "parameterized",
  "rand",
  "rlimit",
  "serde",
@@ -1665,7 +1703,7 @@ version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -260,17 +260,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -368,42 +357,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
- "proc-macro-error",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -481,10 +472,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -682,7 +673,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -752,12 +743,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -778,13 +763,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -881,16 +863,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
@@ -914,7 +886,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1105,7 +1077,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1129,12 +1101,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking"
@@ -1218,7 +1184,7 @@ checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
@@ -1230,30 +1196,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1523,7 +1465,7 @@ checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1589,9 +1531,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subprocess"
@@ -1601,17 +1543,6 @@ checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1626,12 +1557,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
+name = "terminal_size"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "winapi-util",
+ "rustix 0.38.34",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1644,12 +1576,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -1668,7 +1594,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1739,7 +1665,7 @@ version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1765,7 +1691,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1875,7 +1801,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1909,7 +1835,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1951,15 +1877,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2142,5 +2059,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ subprocess = "0.2.6"
 text_placeholder = { version = "0.5", features = ["struct_context"] }
 
 [dev-dependencies]
+parameterized = "2.0.0"
 wait-timeout = "0.2"
 
 [package.metadata.deb]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ exclude = [
 ]
 
 [dependencies]
+clap = { version = "3.0", features = ["derive"] }
 colored = "2.1.0"
-structopt = "0.3.20"
 async-std = "1.7.0"
 futures = "0.3"
 rlimit = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
 colored = "2.1.0"
 async-std = "1.7.0"
 futures = "0.3"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,9 @@
 //! Provides a means to read, parse and hold configuration options for scans.
+use clap::{arg_enum, StructOpt};
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use structopt::{clap::arg_enum, StructOpt};
 
 const LOWEST_PORT_NUMBER: u16 = 1;
 const TOP_PORT_NUMBER: u16 = 65535;
@@ -64,7 +64,7 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
 }
 
 #[derive(StructOpt, Debug, Clone)]
-#[structopt(name = "rustscan", setting = structopt::clap::AppSettings::TrailingVarArg)]
+#[structopt(name = "rustscan", setting = clap::AppSettings::TrailingVarArg)]
 #[allow(clippy::struct_excessive_bools)]
 /// Fast Port Scanner built in Rust.
 /// WARNING Do not use this program against sensitive infrastructure since the
@@ -127,11 +127,11 @@ pub struct Opts {
     /// The order of scanning to be performed. The "serial" option will
     /// scan ports in ascending order while the "random" option will scan
     /// ports randomly.
-    #[structopt(long, possible_values = &ScanOrder::variants(), case_insensitive = true, default_value = "serial")]
+    #[structopt(long, possible_values = ScanOrder::variants(), case_insensitive = true, default_value = "serial")]
     pub scan_order: ScanOrder,
 
     /// Level of scripting required for the run.
-    #[structopt(long, possible_values = &ScriptsRequired::variants(), case_insensitive = true, default_value = "default")]
+    #[structopt(long, possible_values = ScriptsRequired::variants(), case_insensitive = true, default_value = "default")]
     pub scripts: ScriptsRequired,
 
     /// Use the top 1000 ports.
@@ -309,7 +309,10 @@ pub fn default_config_path() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use clap::CommandFactory;
+
     use super::{Config, Opts, PortRange, ScanOrder, ScriptsRequired};
+
     impl Config {
         fn default() -> Self {
             Self {
@@ -329,6 +332,11 @@ mod tests {
                 exclude_ports: None,
             }
         }
+    }
+
+    #[test]
+    fn verify_cli() {
+        Opts::command().debug_assert();
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -310,7 +310,8 @@ pub fn default_config_path() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use clap::CommandFactory;
+    use clap::{CommandFactory, Parser};
+    use parameterized::parameterized;
 
     use super::{Config, Opts, PortRange, ScanOrder, ScriptsRequired};
 
@@ -338,6 +339,26 @@ mod tests {
     #[test]
     fn verify_cli() {
         Opts::command().debug_assert();
+    }
+
+    #[parameterized(input = {
+        vec!["rustscan", "--addresses", "127.0.0.1"],
+        vec!["rustscan", "--addresses", "127.0.0.1", "--", "-sCV"],
+        vec!["rustscan", "--addresses", "127.0.0.1", "--", "-A"],
+        vec!["rustscan", "-t", "1500", "-a", "127.0.0.1", "--", "-A", "-sC"],
+        vec!["rustscan", "--addresses", "127.0.0.1", "--", "--script", r#""'(safe and vuln)'""#],
+    }, command = {
+        vec![],
+        vec!["-sCV".to_owned()],
+        vec!["-A".to_owned()],
+        vec!["-A".to_owned(), "-sC".to_owned()],
+        vec!["--script".to_owned(), "\"'(safe and vuln)'\"".to_owned()],
+    })]
+    fn parse_trailing_command(input: Vec<&str>, command: Vec<String>) {
+        let opts = Opts::parse_from(input);
+
+        assert_eq!(vec!["127.0.0.1".to_owned()], opts.addresses);
+        assert_eq!(command, opts.command);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! Provides a means to read, parse and hold configuration options for scans.
-use clap::{arg_enum, StructOpt};
+use clap::{Parser, ValueEnum};
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -8,28 +8,24 @@ use std::path::PathBuf;
 const LOWEST_PORT_NUMBER: u16 = 1;
 const TOP_PORT_NUMBER: u16 = 65535;
 
-arg_enum! {
-    /// Represents the strategy in which the port scanning will run.
-    ///   - Serial will run from start to end, for example 1 to 1_000.
-    ///   - Random will randomize the order in which ports will be scanned.
-    #[derive(Deserialize, Debug, StructOpt, Clone, Copy, PartialEq, Eq)]
-    pub enum ScanOrder {
-        Serial,
-        Random,
-    }
+/// Represents the strategy in which the port scanning will run.
+///   - Serial will run from start to end, for example 1 to 1_000.
+///   - Random will randomize the order in which ports will be scanned.
+#[derive(Deserialize, Debug, ValueEnum, Clone, Copy, PartialEq, Eq)]
+pub enum ScanOrder {
+    Serial,
+    Random,
 }
 
-arg_enum! {
-    /// Represents the scripts variant.
-    ///   - none will avoid running any script, only portscan results will be shown.
-    ///   - default will run the default embedded nmap script, that's part of RustScan since the beginning.
-    ///   - custom will read the ScriptConfig file and the available scripts in the predefined folders
-    #[derive(Deserialize, Debug, StructOpt, Clone, PartialEq, Eq, Copy)]
-    pub enum ScriptsRequired {
-        None,
-        Default,
-        Custom,
-    }
+/// Represents the scripts variant.
+///   - none will avoid running any script, only portscan results will be shown.
+///   - default will run the default embedded nmap script, that's part of RustScan since the beginning.
+///   - custom will read the ScriptConfig file and the available scripts in the predefined folders
+#[derive(Deserialize, Debug, ValueEnum, Clone, PartialEq, Eq, Copy)]
+pub enum ScriptsRequired {
+    None,
+    Default,
+    Custom,
 }
 
 /// Represents the range of ports to be scanned.
@@ -63,8 +59,13 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
     }
 }
 
-#[derive(StructOpt, Debug, Clone)]
-#[structopt(name = "rustscan", setting = clap::AppSettings::TrailingVarArg)]
+#[derive(Parser, Debug, Clone)]
+#[command(
+    name = "rustscan",
+    version = env!("CARGO_PKG_VERSION"),
+    max_term_width = 120,
+    help_template = "{bin} {version}\n{about}\n\nUSAGE:\n    {usage}\n\nOPTIONS:\n{options}",
+)]
 #[allow(clippy::struct_excessive_bools)]
 /// Fast Port Scanner built in Rust.
 /// WARNING Do not use this program against sensitive infrastructure since the
@@ -73,69 +74,69 @@ fn parse_range(input: &str) -> Result<PortRange, String> {
 /// - GitHub <https://github.com/RustScan/RustScan>
 pub struct Opts {
     /// A comma-delimited list or newline-delimited file of separated CIDRs, IPs, or hosts to be scanned.
-    #[structopt(short, long, use_delimiter = true)]
+    #[arg(short, long, value_delimiter = ',')]
     pub addresses: Vec<String>,
 
     /// A list of comma separated ports to be scanned. Example: 80,443,8080.
-    #[structopt(short, long, use_delimiter = true)]
+    #[arg(short, long, value_delimiter = ',')]
     pub ports: Option<Vec<u16>>,
 
     /// A range of ports with format start-end. Example: 1-1000.
-    #[structopt(short, long, conflicts_with = "ports", parse(try_from_str = parse_range))]
+    #[arg(short, long, conflicts_with = "ports", value_parser = parse_range)]
     pub range: Option<PortRange>,
 
     /// Whether to ignore the configuration file or not.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub no_config: bool,
 
     /// Custom path to config file
-    #[structopt(short, long, parse(from_os_str))]
+    #[arg(short, long, value_parser)]
     pub config_path: Option<PathBuf>,
 
     /// Greppable mode. Only output the ports. No Nmap. Useful for grep or outputting to a file.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub greppable: bool,
 
     /// Accessible mode. Turns off features which negatively affect screen readers.
-    #[structopt(long)]
+    #[arg(long)]
     pub accessible: bool,
 
     /// A comma-delimited list or file of DNS resolvers.
-    #[structopt(long)]
+    #[arg(long)]
     pub resolver: Option<String>,
 
     /// The batch size for port scanning, it increases or slows the speed of
     /// scanning. Depends on the open file limit of your OS.  If you do 65535
     /// it will do every port at the same time. Although, your OS may not
     /// support this.
-    #[structopt(short, long, default_value = "4500")]
+    #[arg(short, long, default_value = "4500")]
     pub batch_size: u16,
 
     /// The timeout in milliseconds before a port is assumed to be closed.
-    #[structopt(short, long, default_value = "1500")]
+    #[arg(short, long, default_value = "1500")]
     pub timeout: u32,
 
     /// The number of tries before a port is assumed to be closed.
     /// If set to 0, rustscan will correct it to 1.
-    #[structopt(long, default_value = "1")]
+    #[arg(long, default_value = "1")]
     pub tries: u8,
 
     /// Automatically ups the ULIMIT with the value you provided.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub ulimit: Option<u64>,
 
     /// The order of scanning to be performed. The "serial" option will
     /// scan ports in ascending order while the "random" option will scan
     /// ports randomly.
-    #[structopt(long, possible_values = ScanOrder::variants(), case_insensitive = true, default_value = "serial")]
+    #[arg(long, value_enum, ignore_case = true, default_value = "serial")]
     pub scan_order: ScanOrder,
 
     /// Level of scripting required for the run.
-    #[structopt(long, possible_values = ScriptsRequired::variants(), case_insensitive = true, default_value = "default")]
+    #[arg(long, value_enum, ignore_case = true, default_value = "default")]
     pub scripts: ScriptsRequired,
 
     /// Use the top 1000 ports.
-    #[structopt(long)]
+    #[arg(long)]
     pub top: bool,
 
     /// The Script arguments to run.
@@ -143,18 +144,18 @@ pub struct Opts {
     /// Example: 'rustscan -t 1500 -a 127.0.0.1 -- -A -sC'.
     /// This command adds -Pn -vvv -p $PORTS automatically to nmap.
     /// For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"
-    #[structopt(last = true)]
+    #[arg(last = true)]
     pub command: Vec<String>,
 
     /// A list of comma separated ports to be excluded from scanning. Example: 80,443,8080.
-    #[structopt(short, long, use_delimiter = true)]
+    #[arg(short, long, value_delimiter = ',')]
     pub exclude_ports: Option<Vec<u16>>,
 }
 
 #[cfg(not(tarpaulin_include))]
 impl Opts {
     pub fn read() -> Self {
-        let mut opts = Opts::from_args();
+        let mut opts = Opts::parse();
 
         if opts.ports.is_none() && opts.range.is_none() {
             opts.range = Some(PortRange {


### PR DESCRIPTION
Prompted by the `atty` issue raised by Dependabot, move to `clap` as this doesn't have that dependency and, as per the [`structopt` README](https://github.com/TeXitoi/structopt#maintenance), that crate is now in maintenance mode.

**Note** that they aren't _exactly_ the same:

Previous:

```sh
rustscan 2.2.3
Fast Port Scanner built in Rust. WARNING Do not use this program against sensitive infrastructure since the specified
server may not be able to handle this many socket connections at once. - Discord  <http://discord.skerritt.blog> -
GitHub <https://github.com/RustScan/RustScan>

USAGE:
    rustscan [FLAGS] [OPTIONS] [-- <command>...]

FLAGS:
        --accessible    Accessible mode. Turns off features which negatively affect screen readers
    -g, --greppable     Greppable mode. Only output the ports. No Nmap. Useful for grep or outputting to a file
    -h, --help          Prints help information
    -n, --no-config     Whether to ignore the configuration file or not
        --top           Use the top 1000 ports
    -V, --version       Prints version information

OPTIONS:
    -a, --addresses <addresses>...            A comma-delimited list or newline-delimited file of separated CIDRs, IPs,
                                              or hosts to be scanned
    -b, --batch-size <batch-size>             The batch size for port scanning, it increases or slows the speed of
                                              scanning. Depends on the open file limit of your OS.  If you do 65535 it
                                              will do every port at the same time. Although, your OS may not support
                                              this [default: 4500]
    -c, --config-path <config-path>           Custom path to config file
    -e, --exclude-ports <exclude-ports>...    A list of comma separated ports to be excluded from scanning. Example:
                                              80,443,8080
    -p, --ports <ports>...                    A list of comma separated ports to be scanned. Example: 80,443,8080
    -r, --range <range>                       A range of ports with format start-end. Example: 1-1000
        --resolver <resolver>                 A comma-delimited list or file of DNS resolvers
        --scan-order <scan-order>             The order of scanning to be performed. The "serial" option will scan ports
                                              in ascending order while the "random" option will scan ports randomly
                                              [default: serial]  [possible values: Serial, Random]
        --scripts <scripts>                   Level of scripting required for the run [default: default]  [possible
                                              values: None, Default, Custom]
    -t, --timeout <timeout>                   The timeout in milliseconds before a port is assumed to be closed
                                              [default: 1500]
        --tries <tries>                       The number of tries before a port is assumed to be closed. If set to 0,
                                              rustscan will correct it to 1 [default: 1]
    -u, --ulimit <ulimit>                     Automatically ups the ULIMIT with the value you provided

ARGS:
    <command>...    The Script arguments to run. To use the argument -A, end RustScan's args with '-- -A'. Example:
                    'rustscan -t 1500 -a 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS automatically to
                    nmap. For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and
                    vuln)'\"
```

New:

```sh
rustscan 2.2.3
Fast Port Scanner built in Rust. WARNING Do not use this program against sensitive infrastructure since the specified
server may not be able to handle this many socket connections at once. - Discord  <http://discord.skerritt.blog> -
GitHub <https://github.com/RustScan/RustScan>

Usage: rustscan [OPTIONS] [-- <COMMAND>...]

Arguments:
  [COMMAND]...  The Script arguments to run. To use the argument -A, end RustScan's args with '-- -A'. Example:
                'rustscan -t 1500 -a 127.0.0.1 -- -A -sC'. This command adds -Pn -vvv -p $PORTS automatically to nmap.
                For things like --script '(safe and vuln)' enclose it in quotations marks \"'(safe and vuln)'\"

Options:
  -a, --addresses <ADDRESSES>          A comma-delimited list or newline-delimited file of separated CIDRs, IPs, or
                                       hosts to be scanned
  -p, --ports <PORTS>                  A list of comma separated ports to be scanned. Example: 80,443,8080
  -r, --range <RANGE>                  A range of ports with format start-end. Example: 1-1000
  -n, --no-config                      Whether to ignore the configuration file or not
  -c, --config-path <CONFIG_PATH>      Custom path to config file
  -g, --greppable                      Greppable mode. Only output the ports. No Nmap. Useful for grep or outputting to
                                       a file
      --accessible                     Accessible mode. Turns off features which negatively affect screen readers
      --resolver <RESOLVER>            A comma-delimited list or file of DNS resolvers
  -b, --batch-size <BATCH_SIZE>        The batch size for port scanning, it increases or slows the speed of scanning.
                                       Depends on the open file limit of your OS.  If you do 65535 it will do every port
                                       at the same time. Although, your OS may not support this [default: 4500]
  -t, --timeout <TIMEOUT>              The timeout in milliseconds before a port is assumed to be closed [default: 1500]
      --tries <TRIES>                  The number of tries before a port is assumed to be closed. If set to 0, rustscan
                                       will correct it to 1 [default: 1]
  -u, --ulimit <ULIMIT>                Automatically ups the ULIMIT with the value you provided
      --scan-order <SCAN_ORDER>        The order of scanning to be performed. The "serial" option will scan ports in
                                       ascending order while the "random" option will scan ports randomly [default:
                                       serial] [possible values: serial, random]
      --scripts <SCRIPTS>              Level of scripting required for the run [default: default] [possible values:
                                       none, default, custom]
      --top                            Use the top 1000 ports
  -e, --exclude-ports <EXCLUDE_PORTS>  A list of comma separated ports to be excluded from scanning. Example:
                                       80,443,8080
  -h, --help                           Print help
```

The `FLAGS`/`OPTIONS` distinction has been completely dropped in `clap` (and isn't even configurable via the `help_template` functionality).