### PR TITLE
ci: refactor ci/cd and extends matrix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Build
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
   schedule:
     - cron: '00 01 * * *'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,11 @@
-name: Publish Docker image
+name: Release - Distribute Docker image
 
 on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    paths-ignore:
+      - '.github/**'
   schedule:
   # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
   - cron: "0 9 * * *"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,7 @@ jobs:
           done
 
       - name: Upload binaries to release
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -210,5 +211,6 @@ jobs:
       #     COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
       - run: cargo publish --token ${CRATES_TOKEN}
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'release'
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
-name: Release
+name: Release - Distribute binaries
 on:
+  # If we want to make release using github interface.
+  # release:
+  #   types: [published]
+  # If we want to make release by pushing new tag.
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
@@ -15,17 +19,29 @@ env:
   BIN_NAME: rustscan
   PROJECT_NAME: rustscan
   REPO_NAME: RustScan/RustScan
-  # BREW_TAP: RustScan/homebrew-tap
+  BREW_TAP: RustScan/homebrew-tap
 
 jobs:
-  dist:
-    name: Dist
+  build:
+    name: Build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
+        # aarch64-linux is failing due to python3 missing issues during tests. I'm removing it for now.
+        # build: [x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos, x86_64-windows, x86_64-win-gnu]
+        build: [x86_64-linux, x86_64-macos, aarch64-macos, x86_64-windows, x86_64-win-gnu]
         include:
+          - build: aarch64-macos
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-darwin
+            cross: true
+          # - build: aarch64-linux
+          #   os: ubuntu-20.04
+          #   rust: stable
+          #   target: aarch64-unknown-linux-gnu
+          #   cross: true
           - build: x86_64-linux
             os: ubuntu-20.04
             rust: stable
@@ -41,22 +57,11 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
             cross: false
-        # - build: aarch64-linux
-        #   os: ubuntu-20.04
-        #   rust: stable
-        #   target: aarch64-unknown-linux-gnu
-        # - build: aarch64-macos
-        #   os: macos-latest
-        #   rust: stable
-        #   target: aarch64-apple-darwin
-        # - build: x86_64-win-gnu
-        #   os: windows-2019
-        #   rust: stable-x86_64-gnu
-        #   target: x86_64-pc-windows-gnu
-        # - build: win32-msvc
-        #   os: windows-2019
-        #   rust: stable
-        #   target: i686-pc-windows-msvc
+          - build: x86_64-win-gnu
+            os: windows-2019
+            rust: stable-x86_64-gnu
+            target: x86_64-pc-windows-gnu
+            cross: false
 
     steps:
       - name: Set Git config. (windows only)
@@ -67,8 +72,11 @@ jobs:
           git config --global pack.threads "1" 
           git config --global pack.deltaCacheSize "512m"
 
-      - name: Install python 3.10 for windows
-        if: contains(matrix.build, 'windows') # Windows is missing some dependencies
+      - name: Install dependencies
+        if: contains(matrix.build, 'aarch64-linux') # Windows is missing some dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu python3
+
+      - name: Install python 3.10
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -101,23 +109,17 @@ jobs:
           args: --release --locked --target ${{ matrix.target }}
 
       - name: Calculate tag name
-        if: contains(matrix.build, 'linux')
+        # if: contains(matrix.build, 'linux')
+        shell: bash
         run: |
           name=dev
           if [[ ${GITHUB_REF} =~ refs/tags/[0-9]+.[0-9]+.[0-9]+ ]]; then
             name=${GITHUB_REF#refs/tags/}
           fi
-          echo ::set-output name=val::$name
-          echo TAG=$name >> $GITHUB_ENV
+          echo "TAG=$name" >> $GITHUB_ENV
         id: tagname
 
-      - name: Build deb package (linux only)
-        if: contains(matrix.build, 'linux')
-        run: |
-          cargo install cargo-deb
-          cargo deb --target ${{ matrix.target }} --deb-version ${TAG}
-
-      - name: Build archive
+      - name: Build and package artifacts
         shell: bash
         run: |
           mkdir dist
@@ -128,17 +130,19 @@ jobs:
           fi
 
           if [[ "${{ matrix.build }}" =~ "linux" ]]; then
-            cp "target/${{ matrix.target }}/debian/rustscan_${TAG}_amd64.deb" "dist/"
+            cargo install cargo-deb
+            cargo deb --target ${{ matrix.target }} --deb-version ${TAG}
+            cp "target/${{ matrix.target }}/debian/rustscan_${TAG}_amd64.deb" "dist/" || true
           fi
+
       - uses: actions/upload-artifact@v4.3.3
         with:
           name: bins-${{ matrix.build }}
           path: dist
 
-  publish:
-    name: Publish
-    needs: [dist]
-    if: contains(fromJson('["push", "schedule"]'), github.event_name) && startsWith(github.ref, 'refs/tags/')
+  package:
+    name: Package
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -147,19 +151,18 @@ jobs:
           submodules: false
 
       - uses: actions/download-artifact@v4
-        # with:
-        #   path: dist
-      # - run: ls -al ./dist
-      - run: ls -al bins-*
+        with:
+          path: dist
 
       - name: Calculate tag name
+        # if: contains(matrix.build, 'linux')
+        shell: bash
         run: |
           name=dev
           if [[ ${GITHUB_REF} =~ refs/tags/[0-9]+.[0-9]+.[0-9]+ ]]; then
             name=${GITHUB_REF#refs/tags/}
           fi
-          echo ::set-output name=val::$name
-          echo TAG=$name >> $GITHUB_ENV
+          echo "TAG=$name" >> $GITHUB_ENV
         id: tagname
 
       - name: Build archive
@@ -168,28 +171,24 @@ jobs:
           set -ex
           rm -rf tmp
           mkdir tmp
-          mkdir dist
-          for dir in bins-* ; do
-              platform=${dir#"bins-"}
+          for dir in dist/bins-* ; do
+              platform=${dir#"dist/bins-"}
               unset exe
-              if [[ $platform =~ "windows" ]]; then
+              if [[ $platform =~ "win" ]]; then
                   exe=".exe"
               fi
               pkgname=$PROJECT_NAME-$TAG-$platform
               mkdir tmp/$pkgname
-              # cp LICENSE README.md tmp/$pkgname
-              mv bins-$platform/$BIN_NAME$exe tmp/$pkgname
+              cp $dir/$BIN_NAME$exe dist/ || true
+              mv $dir/$BIN_NAME$exe tmp/$pkgname
               chmod +x tmp/$pkgname/$BIN_NAME$exe
 
               if [[ $platform =~ "linux" ]]; then
-                  mv "bins-$platform/rustscan_${TAG}_amd64.deb" dist/
+                  mv "$dir/rustscan_${TAG}_amd64.deb" dist/ || true
               fi
 
-              if [ "$exe" = "" ]; then
-                  tar cJf dist/$pkgname.tar.xz -C tmp $pkgname
-              else
-                  (cd tmp && 7z a -r ../dist/$pkgname.zip $pkgname)
-              fi
+              tar cJf dist/$pkgname.tar.xz -C tmp $pkgname
+              7z a dist/$pkgname.zip tmp/$pkgname
           done
 
       - name: Upload binaries to release
@@ -198,48 +197,18 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*
           file_glob: true
-          tag: ${{ steps.tagname.outputs.val }}
+          tag: ${{ github.ref }}
           overwrite: true
 
-      - name: Extract version
-        id: extract-version
-        run: |
-          printf "::set-output name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}"
-      - uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-path: ${{env.PROJECT_NAME}}.rb
-          homebrew-tap: ${{ env.BREW_TAP }}
-          download-url: 'https://github.com/${{ env.REPO_NAME }}/releases/download/${{ steps.extract-version.outputs.tag-name }}/${{env.PROJECT_NAME}}-${{ steps.extract-version.outputs.tag-name }}-x86_64-macos.tar.xz'
-          commit-message: updating formula for ${{ env.PROJECT_NAME }}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-        #
-        # you can use this initial file in your homebrew-tap if you don't have an initial formula:
-        # <projectname>.rb
-        #
-        # class <Projectname capitalized> < Formula
-        #   desc "A test formula"
-        #   homepage "http://www.example.com"
-        #   url "-----"
-        #   version "-----"
-        #   sha256 "-----"
+      # - uses: mislav/bump-homebrew-formula-action@v3
+      #   with:
+      #     formula-path: ${{env.PROJECT_NAME}}.rb
+      #     homebrew-tap: ${{ env.BREW_TAP }}
+      #     download-url: 'https://github.com/${{ env.REPO_NAME }}/releases/download/${{ github.ref }}/${{env.PROJECT_NAME}}-${{ github.ref }}-x86_64-macos.tar.xz'
+      #     commit-message: updating formula for ${{ env.PROJECT_NAME }}
+      #   env:
+      #     COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
-        #   def install
-        #     bin.install "<bin-name>"
-        #   end
-        # end
-
-      # Uncomment this section if you want to release your package to crates.io
-      # Before publishing, make sure you have filled out the following fields:
-      # license or license-file, description, homepage, documentation, repository, readme.
-      # Read more: https://doc.rust-lang.org/cargo/reference/publishing.html
-
-      - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
       - run: cargo publish --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,15 +49,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -926,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,9 +1444,10 @@ dependencies = [
 
 [[package]]
 name = "rustscan"
-version = "2.2.3"
+version = "2.2.4-rc1"
 dependencies = [
  "ansi_term",
+ "anstream",
  "anyhow",
  "async-std",
  "cidr-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustscan/rustscan"
 license = "MIT"
 keywords = ["port", "scanning", "nmap"]
 categories = ["command-line-utilities"]
-readme="README.md"
+readme = "README.md"
 exclude = [
     ".github/*",
     "pictures/*",
@@ -24,6 +24,7 @@ futures = "0.3"
 rlimit = "0.10.1"
 log = "0.4.0"
 env_logger = "0.11.3"
+anstream = "=0.6.14"
 dirs = "5.0.1"
 gcd = "2.0.1"
 rand = "0.8.5"


### PR DESCRIPTION
Hey @bee-san !

I'm wanted to improve the delivery and ease of use for people.
I improve the release CI/CD and publish more format of RustScan.

Now, when you do a release, the release will be delivered with:
- rustscan.exe
- ruscan (linux x86_64 binary)
- debian package
- cross-build as .zip
- cross-build as .tar.xz

I fixed a minor bug in the CI.
And I tried to add support for aarch64-linux build, but it's too complicated for the moment...

Feel free to ask if you need more information !