### PR TITLE
Removed unnecessary `.clone()`s

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -210,8 +210,8 @@ impl Opts {
 
         // Only use top ports when the user asks for them
         if self.top && config.ports.is_some() {
-            let mut ports: Vec<u16> = Vec::with_capacity(config.ports.clone().unwrap().len());
-            for entry in config.ports.clone().unwrap().keys() {
+            let mut ports: Vec<u16> = Vec::with_capacity(config.ports.as_ref().unwrap().len());
+            for entry in config.ports.as_ref().unwrap().keys() {
                 ports.push(entry.parse().unwrap());
             }
             self.ports = Some(ports);


### PR DESCRIPTION
### Explanation
the `.clone()`s displayed below are replaced with `.as_ref()` for enhance performance!

https://github.com/RustScan/RustScan/blob/3873117324a1af07c96d94dca59827665f13f1d0/src/input.rs#L211-L218


## Fix
https://github.com/RustScan/RustScan/blob/ee7d00ec84bc1e8ae6b1d67e90119150ed2dff56/src/input.rs#L211-L218