### PR TITLE
Using references in `init_scripts()` to avoid unnecessary `.clone()`s

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
 
     debug!("Main() `opts` arguments are {:?}", opts);
 
-    let scripts_to_run: Vec<ScriptFile> = match init_scripts(opts.scripts) {
+    let scripts_to_run: Vec<ScriptFile> = match init_scripts(&opts.scripts) {
         Ok(scripts_to_run) => scripts_to_run,
         Err(e) => {
             warning!(

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -79,7 +79,6 @@ use crate::input::ScriptsRequired;
 use anyhow::{anyhow, Result};
 use log::debug;
 use serde_derive::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fs::{self, File};
 use std::io::{self, prelude::*};
@@ -96,7 +95,7 @@ call_format = "nmap -vvv -p {{port}} {{ip}}"
 "#;
 
 #[cfg(not(tarpaulin_include))]
-pub fn init_scripts<'a>(scripts: &'a ScriptsRequired) -> Result<Vec<ScriptFile>> {
+pub fn init_scripts(scripts: &ScriptsRequired) -> Result<Vec<ScriptFile>> {
     let mut scripts_to_run: Vec<ScriptFile> = Vec::new();
 
     match scripts {

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -96,60 +96,48 @@ call_format = "nmap -vvv -p {{port}} {{ip}}"
 "#;
 
 #[cfg(not(tarpaulin_include))]
-pub fn init_scripts(scripts: ScriptsRequired) -> Result<Vec<ScriptFile>> {
+pub fn init_scripts<'a>(scripts: &'a ScriptsRequired) -> Result<Vec<ScriptFile>> {
     let mut scripts_to_run: Vec<ScriptFile> = Vec::new();
 
     match scripts {
-        ScriptsRequired::None => Ok(scripts_to_run),
+        ScriptsRequired::None => {},
         ScriptsRequired::Default => {
             let default_script =
                 toml::from_str::<ScriptFile>(DEFAULT).expect("Failed to parse Script file.");
             scripts_to_run.push(default_script);
-            Ok(scripts_to_run)
         }
         ScriptsRequired::Custom => {
-            let Some(scripts_dir_base) = dirs::home_dir() else {
-                return Err(anyhow!("Could not infer scripts path."));
-            };
-            let script_paths = match find_scripts(scripts_dir_base) {
-                Ok(script_paths) => script_paths,
-                Err(e) => return Err(anyhow!(e)),
-            };
+            let scripts_dir_base = dirs::home_dir().ok_or_else(|| anyhow!("Could not infer scripts path."))?;
+            let script_paths = find_scripts(scripts_dir_base)?;
             debug!("Scripts paths \n{:?}", script_paths);
 
             let parsed_scripts = parse_scripts(script_paths);
             debug!("Scripts parsed \n{:?}", parsed_scripts);
 
-            let script_config = match ScriptConfig::read_config() {
-                Ok(script_config) => script_config,
-                Err(e) => return Err(anyhow!(e)),
-            };
+            let script_config = ScriptConfig::read_config()?;
             debug!("Script config \n{:?}", script_config);
 
             // Only Scripts that contain all the tags found in ScriptConfig will be selected.
-            if script_config.tags.is_some() {
-                let config_hashset: HashSet<String> =
-                    script_config.tags.unwrap().into_iter().collect();
-                for script in &parsed_scripts {
-                    if script.tags.is_some() {
-                        let script_hashset: HashSet<String> =
-                            script.tags.clone().unwrap().into_iter().collect();
-                        if config_hashset.is_subset(&script_hashset) {
-                            scripts_to_run.push(script.clone());
+            if let Some(config_hashset) = script_config.tags {
+                for script in parsed_scripts {
+                    if let Some(script_hashset) = &script.tags {
+                        if script_hashset.iter().all(|tag| config_hashset.contains(tag)) {
+                            scripts_to_run.push(script);
                         } else {
                             debug!(
                                 "\nScript tags does not match config tags {:?} {}",
                                 &script_hashset,
-                                script.path.clone().unwrap().display()
+                                script.path.unwrap().display()
                             );
                         }
                     }
                 }
             }
             debug!("\nScript(s) to run {:?}", scripts_to_run);
-            Ok(scripts_to_run)
         }
     }
+
+    Ok(scripts_to_run)
 }
 
 pub fn parse_scripts(scripts: Vec<PathBuf>) -> Vec<ScriptFile> {

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -100,14 +100,15 @@ pub fn init_scripts<'a>(scripts: &'a ScriptsRequired) -> Result<Vec<ScriptFile>>
     let mut scripts_to_run: Vec<ScriptFile> = Vec::new();
 
     match scripts {
-        ScriptsRequired::None => {},
+        ScriptsRequired::None => {}
         ScriptsRequired::Default => {
             let default_script =
                 toml::from_str::<ScriptFile>(DEFAULT).expect("Failed to parse Script file.");
             scripts_to_run.push(default_script);
         }
         ScriptsRequired::Custom => {
-            let scripts_dir_base = dirs::home_dir().ok_or_else(|| anyhow!("Could not infer scripts path."))?;
+            let scripts_dir_base =
+                dirs::home_dir().ok_or_else(|| anyhow!("Could not infer scripts path."))?;
             let script_paths = find_scripts(scripts_dir_base)?;
             debug!("Scripts paths \n{:?}", script_paths);
 
@@ -121,7 +122,10 @@ pub fn init_scripts<'a>(scripts: &'a ScriptsRequired) -> Result<Vec<ScriptFile>>
             if let Some(config_hashset) = script_config.tags {
                 for script in parsed_scripts {
                     if let Some(script_hashset) = &script.tags {
-                        if script_hashset.iter().all(|tag| config_hashset.contains(tag)) {
+                        if script_hashset
+                            .iter()
+                            .all(|tag| config_hashset.contains(tag))
+                        {
                             scripts_to_run.push(script);
                         } else {
                             debug!(


### PR DESCRIPTION
### ISSUE
the `init_scripts()` function includes a few unnecessary `.clone()`s which could be easily avoided through using references, the error handling is slightly verbose and if statements could also be less verbose by using `if let`.

https://github.com/RustScan/RustScan/blob/9f35cd43bc4124c479d54a0664503b6165fe9dfd/src/scripts/mod.rs#L129-L148

### FIX
https://github.com/RustScan/RustScan/blob/033e2810f28be22610030e1974bf7fb351c9c4a6/src/scripts/mod.rs#L120-L135