### PR TITLE
BugFix: Allow IPV6 addresses to be parsed into NMAP

### DIFF
--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -76,7 +76,6 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::input::ScriptsRequired;
-use anstream::println;
 use anyhow::{anyhow, Result};
 use log::debug;
 use serde_derive::{Deserialize, Serialize};

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -255,7 +255,6 @@ impl Script {
                 script: self.path.unwrap().to_str().unwrap().to_string(),
                 ip: self.ip.to_string(),
                 port: ports_str,
-                //ipversion: ipversion.to_string()
                 ipversion: match &self.ip {
                     IpAddr::V4(_) => String::from("4"),
                     IpAddr::V6(_) => String::from("6")
@@ -266,7 +265,6 @@ impl Script {
             let exec_parts: ExecParts = ExecParts {
                 ip: self.ip.to_string(),
                 port: ports_str,
-                //ipversion: ipversion.to_string()
                 ipversion: match &self.ip {
                     IpAddr::V4(_) => String::from("4"),
                     IpAddr::V6(_) => String::from("6")


### PR DESCRIPTION
Hi,
My ISP defaults to IPV6. I found that the IPV6 version of the domain www.google.es can't be scanned. I attached you a prof one with the domain name translated into IPV6 and the other with the IPV4 address that nslookup resolves.

<img width="1044" alt="Captura de pantalla 2024-07-15 232549" src="https://github.com/user-attachments/assets/ef9578f9-116d-4f59-a7d4-94fdaa28cc60">

This is what I'm referring to

`Open [2a00:1450:4003:80f::2003]:443
[~] Starting Script(s)
2a00:1450:4003:80f::2003 looks like an IPv6 target specification -- you have to use the -6 option.`

I added support to IPV6 by providing the version, both 4 & 6

Regards 🙂
