### PR TITLE
build: allow cargo-tarpaulin config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ strip = true
 [[bin]]
 name = "rustscan"
 path = "src/main.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }


### PR DESCRIPTION
As per Clippy's own recommendation:

```sh
161 | #[cfg(not(tarpaulin_include))]
    |           ^^^^^^^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(tarpaulin_include)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

fixes #646