### PR TITLE
build: remove release on pull-request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/release.yml'
 
 env:
   BIN_NAME: rustscan


### PR DESCRIPTION
Mostly a suggestion at this point: Actions are currently failing due to the default `dev` tag being invalid for some parts of the release workflow.

However, that raises the question as to whether it's appropriate to run a _release_ workflow for a pull-request. I'm suggesting not herein and instead suggesting that this workflow is run only when explicitly tagged and the _build_ workflow should be relied on for testing, etc.