### PR TITLE
fix colors in terminal on windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ extern crate log;
 /// Faster Nmap scanning with Rust
 /// If you're looking for the actual scanning, check out the module Scanner
 fn main() {
+    #[cfg(not(unix))]
+    let _ = ansi_term::enable_ansi_support();
+
     env_logger::init();
     let mut benchmarks = Benchmark::init();
     let mut rustscan_bench = NamedTimer::start("RustScan");


### PR DESCRIPTION
`colored` works on windows terminal but requires a little extra work, used suggested here fix https://github.com/colored-rs/colored/issues/59
this fixes #677