### PR TITLE
build: clippy deny warnings

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 test:
     cargo nextest run
-    cargo clippy 
+    cargo clippy -- --deny warnings
     cargo fmt --check
     cargo doc --workspace --all-features --no-deps --document-private-items
 


### PR DESCRIPTION
Noticed in a recent [Action](https://github.com/RustScan/RustScan/actions/runs/11994571009/job/33437047936) that a `warning` from Clippy doesn't get flagged.

In that spirit, I'm suggesting adding `--deny warnings` to the `cargo clippy` command.
