### PR TITLE
Fix CD release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: CD Pipeline
-
-on: [push]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-nix:


### PR DESCRIPTION
It appears our CD did not run in our pre-release, this tells it to run for tag releases