### PR TITLE
Add documentation to RustScan library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,15 @@
 //!     };
 //!     let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
 //!     let scanner = Scanner::new(
-//!         &addrs,
-//!         10,
-//!         Duration::from_millis(100),
-//!         1,
-//!         true,
-//!         strategy,
-//!         true,
-//!         vec![9000],
-//!         false,
+//!         &addrs, // the addresses to scan
+//!         10, // batch_size is how many ports at a time should be scanned
+//!         Duration::from_millis(100), //T imeout is the time RustScan should wait before declaring a port closed. As datatype Duration.
+//!         1, // Tries, how many retries should RustScan do?
+//!         true, // greppable is whether or not RustScan should print things, or wait until the end to print only the ip
+//!         strategy, // the port strategy used
+//!         true, // accessible, should the output be A11Y compliant?
+//!         vec![9000], // What ports should RustScan exclude?
+//!         false, // is this a UDP scan?
 //!     );
 //!
 //!     let scan_result = block_on(scanner.run());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!         start: 1,
 //!         end: 1_000,
 //!     };
-//!     let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+//!     let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random); // can be serial, random or manual https://github.com/RustScan/RustScan/blob/master/src/port_strategy/mod.rs
 //!     let scanner = Scanner::new(
 //!         &addrs, // the addresses to scan
 //!         10, // batch_size is how many ports at a time should be scanned


### PR DESCRIPTION
Our library is sorely lacking docs. I read this https://docs.rs/rustscan/latest/rustscan/ and had no idea what the arguments are. These comments should hopefully show up :)