### PR TITLE
Add benchmarks for UDP and TCP

### DIFF
--- a/benches/benchmark_portscan.rs
+++ b/benches/benchmark_portscan.rs
@@ -1,16 +1,55 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rustscan::input::{PortRange, ScanOrder};
+use rustscan::port_strategy::PortStrategy;
+use rustscan::scanner::Scanner;
+use std::net::IpAddr;
+use std::time::Duration;
 
-fn fibonacci(n: u64) -> u64 {
-    match n {
-        0 => 1,
-        1 => 1,
-        n => fibonacci(n - 1) + fibonacci(n - 2),
-    }
+fn portscan_tcp() {
+    let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
+    let range = PortRange {
+        start: 1,
+        end: 60_000,
+    };
+    let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Serial);
+    let _scanner = Scanner::new(
+        &addrs,
+        10,
+        Duration::from_millis(100),
+        1,
+        false,
+        strategy,
+        true,
+        vec![],
+        false,
+    );
+    // Perform the actual scan or logic here if needed
+}
+
+fn portscan_udp() {
+    let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
+    let range = PortRange {
+        start: 1,
+        end: 60_000,
+    };
+    let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Serial);
+    let _scanner = Scanner::new(
+        &addrs,
+        10,
+        Duration::from_millis(100),
+        1,
+        false,
+        strategy,
+        true,
+        vec![],
+        true,
+    );
+    // Perform the actual scan or logic here if needed
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("fib 20", |b| b.iter(|| fibonacci(black_box(20))));
+    c.bench_function("portscan tcp", |b| b.iter(|| portscan_tcp()));
+    c.bench_function("portscan udp", |b| b.iter(|| portscan_udp()));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
This CI will fail initially due to an issue fixed in another PR.

This runs the udp scan and tcp scan 100 times and gets an average measure.

Currently these are:

```
portscan tcp            time:   [38.941 ms 39.659 ms 40.397 ms]
                        change: [+62486512% +64310488% +66078003%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking portscan udp: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
portscan udp            time:   [58.419 ms 59.596 ms 60.775 ms]
                        change: [+93198493% +96139097% +98913211%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

Notes:
* TCP scan takes 40ms on average
* UDP scan does not complete all 100 samples, as it's a bit slow. Takes 60ms on average. We should fix this, I couldn't work out how to increase target time 🤷🏻 
* I ran these previously for testing so "performance has regressed" can be ignored
* We scan 1k ports because 64k ports over 100 samples is way too many.