### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -93,7 +93,7 @@ pub fn parse_address(address: &str, resolver: &Resolver) -> Vec<IpAddr> {
         .map(|cidr| cidr.iter().map(|c| c.address()).collect())
         .ok()
         .or_else(|| {
-            format!("{}:{}", &address, 80)
+            format!("{}:80", &address)
                 .to_socket_addrs()
                 .ok()
                 .map(|mut iter| vec![iter.next().unwrap().ip()])

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,22 +200,17 @@ fn main() {
 #[allow(clippy::items_after_statements, clippy::needless_raw_string_hashes)]
 fn print_opening(opts: &Opts) {
     debug!("Printing opening");
-    let s = format!(
-        "{}\n{}\n{}\n{}\n{}",
-        r#".----. .-. .-. .----..---.  .----. .---.   .--.  .-. .-."#,
-        r#"| {}  }| { } |{ {__ {_   _}{ {__  /  ___} / {} \ |  `| |"#,
-        r#"| .-. \| {_} |.-._} } | |  .-._} }\     }/  /\  \| |\  |"#,
-        r#"`-' `-'`-----'`----'  `-'  `----'  `---' `-'  `-'`-' `-'"#,
-        r#"The Modern Day Port Scanner."#
-    );
+    let s = r#".----. .-. .-. .----..---.  .----. .---.   .--.  .-. .-.
+| {}  }| { } |{ {__ {_   _}{ {__  /  ___} / {} \ |  `| |
+| .-. \| {_} |.-._} } | |  .-._} }\     }/  /\  \| |\  |
+`-' `-'`-----'`----'  `-'  `----'  `---' `-'  `-'`-' `-'
+The Modern Day Port Scanner."#;
+
     println!("{}", s.gradient(Color::Green).bold());
-    let info = format!(
-        "{}\n{}\n{}\n{}",
-        r#"________________________________________"#,
-        r#": http://discord.skerritt.blog         :"#,
-        r#": https://github.com/RustScan/RustScan :"#,
-        r#" --------------------------------------"#
-    );
+    let info = r#"________________________________________
+: http://discord.skerritt.blog         :
+: https://github.com/RustScan/RustScan :
+ --------------------------------------"#;
     println!("{}", info.gradient(Color::Yellow).bold());
     funny_opening!();
 

--- a/src/scanner/socket_iterator.rs
+++ b/src/scanner/socket_iterator.rs
@@ -30,7 +30,7 @@ impl<'s> SocketIterator<'s> {
 }
 
 #[allow(clippy::doc_link_with_quotes)]
-impl<'s> Iterator for SocketIterator<'s> {
+impl Iterator for SocketIterator<'_> {
     type Item = SocketAddr;
 
     /// Returns a socket based on the combination of one of the provided


### PR DESCRIPTION
- `format!` macro introduces overhead of creating a new `String` object during runtime. On the contrary, `concat!` macro constructs `&str` during compilation, which is more efficient.