### PR TITLE
chore: fix clippy lists in tests/benchmarks

### DIFF
--- a/benches/benchmark_portscan.rs
+++ b/benches/benchmark_portscan.rs
@@ -15,7 +15,7 @@ fn portscan_udp(scanner: &Scanner) {
 }
 
 fn bench_address() {
-    let _addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
+    let _addrs = ["127.0.0.1".parse::<IpAddr>().unwrap()];
 }
 
 fn bench_port_strategy() {
@@ -71,9 +71,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     udp_group.finish();
 
     // Benching helper functions
-    c.bench_function("parse address", |b| b.iter(|| bench_address()));
+    c.bench_function("parse address", |b| b.iter(bench_address));
 
-    c.bench_function("port strategy", |b| b.iter(|| bench_port_strategy()));
+    c.bench_function("port strategy", |b| b.iter(bench_port_strategy));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 test:
     cargo nextest run
     cargo clippy -- --deny warnings
+    cargo clippy --tests -- --deny warnings
     cargo fmt --check
     cargo doc --workspace --all-features --no-deps --document-private-items
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -193,8 +193,11 @@ mod tests {
 
     #[test]
     fn parse_correct_addresses() {
-        let mut opts = Opts::default();
-        opts.addresses = vec!["127.0.0.1".to_owned(), "192.168.0.0/30".to_owned()];
+        let opts = Opts {
+            addresses: vec!["127.0.0.1".to_owned(), "192.168.0.0/30".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
 
         assert_eq!(
@@ -211,8 +214,11 @@ mod tests {
 
     #[test]
     fn parse_correct_host_addresses() {
-        let mut opts = Opts::default();
-        opts.addresses = vec!["google.com".to_owned()];
+        let opts = Opts {
+            addresses: vec!["google.com".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
 
         assert_eq!(ips.len(), 1);
@@ -220,8 +226,11 @@ mod tests {
 
     #[test]
     fn parse_correct_and_incorrect_addresses() {
-        let mut opts = Opts::default();
-        opts.addresses = vec!["127.0.0.1".to_owned(), "im_wrong".to_owned()];
+        let opts = Opts {
+            addresses: vec!["127.0.0.1".to_owned(), "im_wrong".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
 
         assert_eq!(ips, [Ipv4Addr::new(127, 0, 0, 1),]);
@@ -229,8 +238,11 @@ mod tests {
 
     #[test]
     fn parse_incorrect_addresses() {
-        let mut opts = Opts::default();
-        opts.addresses = vec!["im_wrong".to_owned(), "300.10.1.1".to_owned()];
+        let opts = Opts {
+            addresses: vec!["im_wrong".to_owned(), "300.10.1.1".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
 
         assert!(ips.is_empty());
@@ -238,34 +250,48 @@ mod tests {
     #[test]
     fn parse_hosts_file_and_incorrect_hosts() {
         // Host file contains IP, Hosts, incorrect IPs, incorrect hosts
-        let mut opts = Opts::default();
-        opts.addresses = vec!["fixtures/hosts.txt".to_owned()];
+        let opts = Opts {
+            addresses: vec!["fixtures/hosts.txt".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
+
         assert_eq!(ips.len(), 3);
     }
 
     #[test]
     fn parse_empty_hosts_file() {
         // Host file contains IP, Hosts, incorrect IPs, incorrect hosts
-        let mut opts = Opts::default();
-        opts.addresses = vec!["fixtures/empty_hosts.txt".to_owned()];
+        let opts = Opts {
+            addresses: vec!["fixtures/empty_hosts.txt".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
+
         assert_eq!(ips.len(), 0);
     }
 
     #[test]
     fn parse_naughty_host_file() {
         // Host file contains IP, Hosts, incorrect IPs, incorrect hosts
-        let mut opts = Opts::default();
-        opts.addresses = vec!["fixtures/naughty_string.txt".to_owned()];
+        let opts = Opts {
+            addresses: vec!["fixtures/naughty_string.txt".to_owned()],
+            ..Default::default()
+        };
+
         let ips = parse_addresses(&opts);
+
         assert_eq!(ips.len(), 0);
     }
 
     #[test]
     fn parse_duplicate_cidrs() {
-        let mut opts = Opts::default();
-        opts.addresses = vec!["79.98.104.0/21".to_owned(), "79.98.104.0/24".to_owned()];
+        let opts = Opts {
+            addresses: vec!["79.98.104.0/21".to_owned(), "79.98.104.0/24".to_owned()],
+            ..Default::default()
+        };
 
         let ips = parse_addresses(&opts);
 
@@ -285,9 +311,11 @@ mod tests {
 
     #[test]
     fn resolver_args_google_dns() {
-        let mut opts = Opts::default();
         // https://developers.google.com/speed/public-dns
-        opts.resolver = Some("8.8.8.8,8.8.4.4".to_owned());
+        let opts = Opts {
+            resolver: Some("8.8.8.8,8.8.4.4".to_owned()),
+            ..Default::default()
+        };
 
         let resolver = get_resolver(&opts.resolver);
         let lookup = resolver.lookup_ip("www.example.com.").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,8 +300,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn batch_size_lowered() {
-        let mut opts = Opts::default();
-        opts.batch_size = 50_000;
+        let opts = Opts {
+            batch_size: 50_000,
+            ..Default::default()
+        };
         let batch_size = infer_batch_size(&opts, 120);
 
         assert!(batch_size < opts.batch_size);
@@ -310,8 +312,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn batch_size_lowered_average_size() {
-        let mut opts = Opts::default();
-        opts.batch_size = 50_000;
+        let opts = Opts {
+            batch_size: 50_000,
+            ..Default::default()
+        };
         let batch_size = infer_batch_size(&opts, 9_000);
 
         assert!(batch_size == 3_000);
@@ -321,8 +325,10 @@ mod tests {
     fn batch_size_equals_ulimit_lowered() {
         // because ulimit and batch size are same size, batch size is lowered
         // to ULIMIT - 100
-        let mut opts = Opts::default();
-        opts.batch_size = 50_000;
+        let opts = Opts {
+            batch_size: 50_000,
+            ..Default::default()
+        };
         let batch_size = infer_batch_size(&opts, 5_000);
 
         assert!(batch_size == 4_900);
@@ -331,9 +337,11 @@ mod tests {
     #[cfg(unix)]
     fn batch_size_adjusted_2000() {
         // ulimit == batch_size
-        let mut opts = Opts::default();
-        opts.batch_size = 50_000;
-        opts.ulimit = Some(2_000);
+        let opts = Opts {
+            batch_size: 50_000,
+            ulimit: Some(2_000),
+            ..Default::default()
+        };
         let batch_size = adjust_ulimit_size(&opts);
 
         assert!(batch_size == 2_000);
@@ -342,9 +350,11 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_high_ulimit_no_greppable_mode() {
-        let mut opts = Opts::default();
-        opts.batch_size = 10;
-        opts.greppable = false;
+        let opts = Opts {
+            batch_size: 10,
+            greppable: false,
+            ..Default::default()
+        };
 
         let batch_size = infer_batch_size(&opts, 1_000_000);
 
@@ -353,8 +363,10 @@ mod tests {
 
     #[test]
     fn test_print_opening_no_panic() {
-        let mut opts = Opts::default();
-        opts.ulimit = Some(2_000);
+        let opts = Opts {
+            ulimit: Some(2_000),
+            ..Default::default()
+        };
         // print opening should not panic
         print_opening(&opts);
     }


### PR DESCRIPTION
Completely minor but there are a few linting errors coming out of Clippy but only for the tests.

This should fix the existing ones:

```sh
❯ cargo clippy --tests
   Compiling rustscan v2.3.0 (/home/psypherpunk/git/RustScan)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.49s
```