### PR TITLE
Added --no-banner option

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -89,6 +89,10 @@ pub struct Opts {
     #[arg(short, long)]
     pub no_config: bool,
 
+    /// Hide the banner
+    #[arg(long)]
+    pub no_banner: bool,
+
     /// Custom path to config file
     #[arg(short, long, value_parser)]
     pub config_path: Option<PathBuf>,
@@ -237,6 +241,7 @@ impl Default for Opts {
             resolver: None,
             scan_order: ScanOrder::Serial,
             no_config: true,
+            no_banner: false,
             top: false,
             scripts: ScriptsRequired::Default,
             config_path: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
 
     debug!("Scripts initialized {:?}", &scripts_to_run);
 
-    if !opts.greppable && !opts.accessible {
+    if !opts.greppable && !opts.accessible && !opts.no_banner {
         print_opening(&opts);
     }
 


### PR DESCRIPTION
Added a `--no-banner` option to hide the banner. This is a common option thats seen in other tools such as `wpscan` and `msfconsole` as some users find the banner unnecessary.