### PR TITLE
docs: update link to build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,4 +232,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 [badge-3]: https://img.shields.io/github/downloads/rustscan/rustscan/total?label=GitHub%20Downloads
 [badge-4]: https://img.shields.io/crates/d/rustscan?label=Cargo%20Downloads
 [badge-5]: https://img.shields.io/discord/754001738184392704
-[badge-6]: https://github.com/RustScan/RustScan/workflows/Build/badge.svg?branch=master
+[badge-6]: https://github.com/RustScan/RustScan/actions/workflows/build.yml/badge.svg?branch=master


### PR DESCRIPTION
We're seeing broken links in Actions [recently](https://github.com/RustScan/RustScan/actions/runs/12743816615/job/35514526625):

```sh
ERROR: 1 dead links found!
[✖] https://github.com/RustScan/RustScan/workflows/Build/badge.svg?branch=master → Status: 404
```


This should update the link/badge as per the [docs.](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-branch-parameter).