### PR TITLE
CLI option to also show closed ports

### DIFF
--- a/benches/benchmark_portscan.rs
+++ b/benches/benchmark_portscan.rs
@@ -64,6 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         true,
         vec![],
         false,
+        false,
     );
 
     c.bench_function("portscan tcp", |b| {
@@ -80,6 +81,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         true,
         vec![],
         true,
+        false,
     );
 
     let mut udp_group = c.benchmark_group("portscan udp");

--- a/src/input.rs
+++ b/src/input.rs
@@ -161,6 +161,10 @@ pub struct Opts {
     /// UDP scanning mode, finds UDP ports that send back responses
     #[arg(long)]
     pub udp: bool,
+
+    /// Also show closed Ports
+    #[arg(long)]
+    pub closed: bool,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -200,7 +204,7 @@ impl Opts {
 
         merge_required!(
             addresses, greppable, accessible, batch_size, timeout, tries, scan_order, scripts,
-            command, udp, no_banner
+            command, udp, no_banner, closed
         );
     }
 
@@ -247,6 +251,7 @@ impl Default for Opts {
             exclude_ports: None,
             exclude_addresses: None,
             udp: false,
+            closed: false,
         }
     }
 }
@@ -274,6 +279,7 @@ pub struct Config {
     exclude_addresses: Option<Vec<String>>,
     udp: Option<bool>,
     no_banner: Option<bool>,
+    closed: Option<bool>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -291,6 +297,7 @@ impl Config {
     /// scan_order = "Serial"
     /// exclude_ports = [8080, 9090, 80]
     /// udp = false
+    /// closed = false
     ///
     pub fn read(custom_config_path: Option<PathBuf>) -> Self {
         let mut content = String::new();
@@ -366,6 +373,7 @@ mod tests {
                 exclude_addresses: None,
                 udp: Some(false),
                 no_banner: None,
+                closed: Some(false),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //!         true, // accessible, should the output be A11Y compliant?
 //!         vec![9000], // What ports should RustScan exclude?
 //!         false, // is this a UDP scan?
+//!         false, // Output closed ports?
 //!     );
 //!
 //!     let scan_result = block_on(scanner.run());

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,9 +91,9 @@ fn main() {
         Duration::from_millis(opts.timeout.into()),
         opts.tries,
         opts.greppable,
-        PortStrategy::pick(&opts.range, opts.ports, opts.scan_order),
+        PortStrategy::pick(&opts.range, opts.clone().ports, opts.scan_order),
         opts.accessible,
-        opts.exclude_ports.unwrap_or_default(),
+        opts.exclude_ports.clone().unwrap_or_default(),
         opts.udp,
         opts.closed,
     );
@@ -142,63 +142,29 @@ fn main() {
     }
 
     let mut script_bench = NamedTimer::start("Scripts");
-    for (ip, ports) in &open_ports_per_ip {
-        let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
 
-        // nmap port style is 80,443. Comma separated with no spaces.
-        let ports_str = vec_str_ports.join(",");
-
-        // if option scripts is none, no script will be spawned
-        if opts.greppable || opts.scripts == ScriptsRequired::None {
-            println!("{} -> [{}]", &ip, ports_str);
-            continue;
-        }
-        detail!("Starting Script(s)", opts.greppable, opts.accessible);
-
-        // Run all the scripts we found and parsed based on the script config file tags field.
-        for mut script_f in scripts_to_run.clone() {
-            // This part allows us to add commandline arguments to the Script call_format, appending them to the end of the command.
-            if !opts.command.is_empty() {
-                let user_extra_args = &opts.command.join(" ");
-                debug!("Extra args vec {:?}", user_extra_args);
-                if script_f.call_format.is_some() {
-                    let mut call_f = script_f.call_format.unwrap();
-                    call_f.push(' ');
-                    call_f.push_str(user_extra_args);
-                    output!(
-                        format!("Running script {:?} on ip {}\nDepending on the complexity of the script, results may take some time to appear.", call_f, &ip),
-                        opts.greppable,
-                        opts.accessible
-                    );
-                    debug!("Call format {}", call_f);
-                    script_f.call_format = Some(call_f);
-                }
-            }
-
-            // Building the script with the arguments from the ScriptFile, and ip-ports.
-            let script = Script::build(
-                script_f.path,
-                *ip,
-                ports.clone(),
-                script_f.port,
-                script_f.ports_separator,
-                script_f.tags,
-                script_f.call_format,
-            );
-            match script.run() {
-                Ok(script_result) => {
-                    detail!(script_result.to_string(), opts.greppable, opts.accessible);
-                }
-                Err(e) => {
-                    warning!(&format!("Error {e}"), opts.greppable, opts.accessible);
-                }
-            }
-        }
+    print_summary(open_ports_per_ip, &scripts_to_run, &opts);
+    // We only print closed ports if the user requested it.
+    if opts.closed {
+        println!("closed ports:");
+        print_summary(closed_ports_per_ip, &scripts_to_run, &opts);
     }
 
-    // TODO:
-    println!("closed ports:");
-    for (ip, ports) in &closed_ports_per_ip {
+    // To use the runtime benchmark, run the process as: RUST_LOG=info ./rustscan
+    script_bench.end();
+    benchmarks.push(script_bench);
+    rustscan_bench.end();
+    benchmarks.push(rustscan_bench);
+    debug!("Benchmarks raw {:?}", benchmarks);
+    info!("{}", benchmarks.summary());
+}
+
+fn print_summary(
+    ports_per_ip: HashMap<IpAddr, Vec<u16>>,
+    scripts_to_run: &Vec<ScriptFile>,
+    opts: &Opts,
+) {
+    for (ip, ports) in &ports_per_ip {
         let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
 
         // nmap port style is 80,443. Comma separated with no spaces.

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ extern crate log;
 /// Faster Nmap scanning with Rust
 /// If you're looking for the actual scanning, check out the module Scanner
 fn main() {
+    use rustscan::scanner::PortStatus;
+
     #[cfg(not(unix))]
     let _ = ansi_term::enable_ansi_support();
 
@@ -93,6 +95,7 @@ fn main() {
         opts.accessible,
         opts.exclude_ports.unwrap_or_default(),
         opts.udp,
+        opts.closed,
     );
     debug!("Scanner finished building: {scanner:?}");
 
@@ -101,17 +104,28 @@ fn main() {
     portscan_bench.end();
     benchmarks.push(portscan_bench);
 
-    let mut ports_per_ip = HashMap::new();
+    let mut open_ports_per_ip = HashMap::new();
+    let mut closed_ports_per_ip = HashMap::new();
 
     for socket in scan_result {
-        ports_per_ip
-            .entry(socket.ip())
-            .or_insert_with(Vec::new)
-            .push(socket.port());
+        match socket {
+            PortStatus::Open(socket) => {
+                open_ports_per_ip
+                    .entry(socket.ip())
+                    .or_insert_with(Vec::new)
+                    .push(socket.port());
+            }
+            PortStatus::Closed(socket) => {
+                closed_ports_per_ip
+                    .entry(socket.ip())
+                    .or_insert_with(Vec::new)
+                    .push(socket.port());
+            }
+        }
     }
 
     for ip in ips {
-        if ports_per_ip.contains_key(&ip) {
+        if open_ports_per_ip.contains_key(&ip) || closed_ports_per_ip.contains_key(&ip) {
             continue;
         }
 
@@ -128,7 +142,63 @@ fn main() {
     }
 
     let mut script_bench = NamedTimer::start("Scripts");
-    for (ip, ports) in &ports_per_ip {
+    for (ip, ports) in &open_ports_per_ip {
+        let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
+
+        // nmap port style is 80,443. Comma separated with no spaces.
+        let ports_str = vec_str_ports.join(",");
+
+        // if option scripts is none, no script will be spawned
+        if opts.greppable || opts.scripts == ScriptsRequired::None {
+            println!("{} -> [{}]", &ip, ports_str);
+            continue;
+        }
+        detail!("Starting Script(s)", opts.greppable, opts.accessible);
+
+        // Run all the scripts we found and parsed based on the script config file tags field.
+        for mut script_f in scripts_to_run.clone() {
+            // This part allows us to add commandline arguments to the Script call_format, appending them to the end of the command.
+            if !opts.command.is_empty() {
+                let user_extra_args = &opts.command.join(" ");
+                debug!("Extra args vec {:?}", user_extra_args);
+                if script_f.call_format.is_some() {
+                    let mut call_f = script_f.call_format.unwrap();
+                    call_f.push(' ');
+                    call_f.push_str(user_extra_args);
+                    output!(
+                        format!("Running script {:?} on ip {}\nDepending on the complexity of the script, results may take some time to appear.", call_f, &ip),
+                        opts.greppable,
+                        opts.accessible
+                    );
+                    debug!("Call format {}", call_f);
+                    script_f.call_format = Some(call_f);
+                }
+            }
+
+            // Building the script with the arguments from the ScriptFile, and ip-ports.
+            let script = Script::build(
+                script_f.path,
+                *ip,
+                ports.clone(),
+                script_f.port,
+                script_f.ports_separator,
+                script_f.tags,
+                script_f.call_format,
+            );
+            match script.run() {
+                Ok(script_result) => {
+                    detail!(script_result.to_string(), opts.greppable, opts.accessible);
+                }
+                Err(e) => {
+                    warning!(&format!("Error {e}"), opts.greppable, opts.accessible);
+                }
+            }
+        }
+    }
+
+    // TODO:
+    println!("closed ports:");
+    for (ip, ports) in &closed_ports_per_ip {
         let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
 
         // nmap port style is 80,443. Comma separated with no spaces.

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,11 +142,11 @@ fn main() {
 
     let mut script_bench = NamedTimer::start("Scripts");
 
-    print_summary(open_ports_per_ip, &scripts_to_run, &opts);
+    print_summary(&open_ports_per_ip, &scripts_to_run, &opts);
     // We only print closed ports if the user requested it.
     if opts.closed {
         println!("closed ports:");
-        print_summary(closed_ports_per_ip, &scripts_to_run, &opts);
+        print_summary(&closed_ports_per_ip, &scripts_to_run, &opts);
     }
 
     // To use the runtime benchmark, run the process as: RUST_LOG=info ./rustscan
@@ -154,16 +154,16 @@ fn main() {
     benchmarks.push(script_bench);
     rustscan_bench.end();
     benchmarks.push(rustscan_bench);
-    debug!("Benchmarks raw {:?}", benchmarks);
+    debug!("Benchmarks raw {benchmarks:?}");
     info!("{}", benchmarks.summary());
 }
 
 fn print_summary(
-    ports_per_ip: HashMap<IpAddr, Vec<u16>>,
-    scripts_to_run: &Vec<ScriptFile>,
+    ports_per_ip: &HashMap<IpAddr, Vec<u16>>,
+    scripts_to_run: &[ScriptFile],
     opts: &Opts,
 ) {
-    for (ip, ports) in &ports_per_ip {
+    for (ip, ports) in ports_per_ip {
         let vec_str_ports: Vec<String> = ports.iter().map(ToString::to_string).collect();
 
         // nmap port style is 80,443. Comma separated with no spaces.
@@ -177,7 +177,7 @@ fn print_summary(
         detail!("Starting Script(s)", opts.greppable, opts.accessible);
 
         // Run all the scripts we found and parsed based on the script config file tags field.
-        for mut script_f in scripts_to_run.clone() {
+        for mut script_f in scripts_to_run.iter().cloned() {
             // This part allows us to add commandline arguments to the Script call_format, appending them to the end of the command.
             if !opts.command.is_empty() {
                 let user_extra_args = &opts.command.join(" ");
@@ -216,14 +216,6 @@ fn print_summary(
             }
         }
     }
-
-    // To use the runtime benchmark, run the process as: RUST_LOG=info ./rustscan
-    script_bench.end();
-    benchmarks.push(script_bench);
-    rustscan_bench.end();
-    benchmarks.push(rustscan_bench);
-    debug!("Benchmarks raw {benchmarks:?}");
-    info!("{}", benchmarks.summary());
 }
 
 /// Prints the opening title of RustScan

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::string::ToString;
 use std::time::Duration;
 
 use rustscan::address::parse_addresses;
+use rustscan::scanner::PortStatus;
 
 extern crate colorful;
 extern crate dirs;
@@ -35,8 +36,6 @@ extern crate log;
 /// Faster Nmap scanning with Rust
 /// If you're looking for the actual scanning, check out the module Scanner
 fn main() {
-    use rustscan::scanner::PortStatus;
-
     #[cfg(not(unix))]
     let _ = ansi_term::enable_ansi_support();
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -353,6 +353,7 @@ mod tests {
             true,
             vec![9000],
             false,
+            false,
         );
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -377,6 +378,7 @@ mod tests {
             true,
             vec![9000],
             false,
+            false,
         );
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -400,6 +402,7 @@ mod tests {
             true,
             vec![9000],
             false,
+            false,
         );
         block_on(scanner.run());
         assert_eq!(1, 1);
@@ -421,6 +424,7 @@ mod tests {
             strategy,
             true,
             vec![9000],
+            false,
             false,
         );
         block_on(scanner.run());
@@ -447,6 +451,7 @@ mod tests {
             true,
             vec![9000],
             false,
+            false,
         );
         block_on(scanner.run());
         assert_eq!(1, 1);
@@ -471,6 +476,7 @@ mod tests {
             true,
             vec![9000],
             true,
+            false,
         );
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -495,6 +501,7 @@ mod tests {
             true,
             vec![9000],
             true,
+            false,
         );
         block_on(scanner.run());
         // if the scan fails, it wouldn't be able to assert_eq! as it panicked!
@@ -518,6 +525,7 @@ mod tests {
             true,
             vec![9000],
             true,
+            false,
         );
         block_on(scanner.run());
         assert_eq!(1, 1);
@@ -540,6 +548,7 @@ mod tests {
             true,
             vec![9000],
             true,
+            false,
         );
         block_on(scanner.run());
         assert_eq!(1, 1);

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -37,6 +37,13 @@ pub struct Scanner {
     accessible: bool,
     exclude_ports: Vec<u16>,
     udp: bool,
+    closed: bool,
+}
+
+#[derive(Debug)]
+pub enum PortStatus {
+    Open(SocketAddr),
+    Closed(SocketAddr),
 }
 
 // Allowing too many arguments for clippy.
@@ -52,6 +59,7 @@ impl Scanner {
         accessible: bool,
         exclude_ports: Vec<u16>,
         udp: bool,
+        closed: bool,
     ) -> Self {
         Self {
             batch_size,
@@ -63,13 +71,14 @@ impl Scanner {
             accessible,
             exclude_ports,
             udp,
+            closed,
         }
     }
 
     /// Runs scan_range with chunk sizes
     /// If you want to run RustScan normally, this is the entry point used
     /// Returns all open ports as `Vec<u16>`
-    pub async fn run(&self) -> Vec<SocketAddr> {
+    pub async fn run(&self) -> Vec<PortStatus> {
         let ports: Vec<u16> = self
             .port_strategy
             .order()
@@ -78,7 +87,7 @@ impl Scanner {
             .copied()
             .collect();
         let mut socket_iterator: SocketIterator = SocketIterator::new(&self.ips, &ports);
-        let mut open_sockets: Vec<SocketAddr> = Vec::new();
+        let mut found_sockets: Vec<PortStatus> = Vec::new();
         let mut ftrs = FuturesUnordered::new();
         let mut errors: HashSet<String> = HashSet::new();
         let udp_map = get_parsed_data();
@@ -103,7 +112,7 @@ impl Scanner {
             }
 
             match result {
-                Ok(socket) => open_sockets.push(socket),
+                Ok(socket) => found_sockets.push(socket),
                 Err(e) => {
                     let error_string = e.to_string();
                     if errors.len() < self.ips.len() * 1000 {
@@ -113,8 +122,8 @@ impl Scanner {
             }
         }
         debug!("Typical socket connection errors {errors:?}");
-        debug!("Open Sockets found: {:?}", &open_sockets);
-        open_sockets
+        debug!("Open Sockets found: {:?}", &found_sockets);
+        found_sockets
     }
 
     /// Given a socket, scan it self.tries times.
@@ -135,7 +144,7 @@ impl Scanner {
         &self,
         socket: SocketAddr,
         udp_map: BTreeMap<Vec<u16>, Vec<u8>>,
-    ) -> io::Result<SocketAddr> {
+    ) -> io::Result<PortStatus> {
         if self.udp {
             return self.scan_udp_socket(socket, udp_map).await;
         }
@@ -154,10 +163,22 @@ impl Scanner {
                     self.fmt_ports(socket);
 
                     debug!("Return Ok after {nr_try} tries");
-                    return Ok(socket);
+                    return Ok(PortStatus::Open(socket));
                 }
                 Err(e) => {
                     let mut error_string = e.to_string();
+
+                    if e.kind() == io::ErrorKind::ConnectionRefused {
+                        if !self.greppable {
+                            if self.accessible {
+                                println!("Closed {socket}");
+                            } else {
+                                println!("Closed {}", socket.to_string().red());
+                            }
+                        }
+
+                        return Ok(PortStatus::Closed(socket));
+                    }
 
                     assert!(!error_string.to_lowercase().contains("too many open files"), "Too many open files. Please reduce batch size. The default is 5000. Try -b 2500.");
 
@@ -176,7 +197,7 @@ impl Scanner {
         &self,
         socket: SocketAddr,
         udp_map: BTreeMap<Vec<u16>, Vec<u8>>,
-    ) -> io::Result<SocketAddr> {
+    ) -> io::Result<PortStatus> {
         let mut payload: Vec<u8> = Vec::new();
         for (key, value) in udp_map {
             if key.contains(&socket.port()) {
@@ -187,7 +208,7 @@ impl Scanner {
         let tries = self.tries.get();
         for _ in 1..=tries {
             match self.udp_scan(socket, &payload, self.timeout).await {
-                Ok(true) => return Ok(socket),
+                Ok(true) => return Ok(PortStatus::Open(socket)),
                 Ok(false) => continue,
                 Err(e) => return Err(e),
             }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -169,7 +169,7 @@ impl Scanner {
                     let mut error_string = e.to_string();
 
                     if e.kind() == io::ErrorKind::ConnectionRefused {
-                        if !self.greppable {
+                        if !self.greppable && self.closed {
                             if self.accessible {
                                 println!("Closed {socket}");
                             } else {


### PR DESCRIPTION
This PR introduces the new CLI option `--closed`, which enables the option to also show ports which are closed.

From a security perspective, it is very useful information to see whether we got any response at all for a given port, even when the response is a RST (conn-refused).
It can indicate that our request was denied (or specifically blocked by a firewall).


Currently this behavior is behind the `--closed` CLI flag and not enabled by default.
Nmap, for example, shows closed ports by default.

Regarding the output of the `--closed` option, it mimics the output for open ports, but instead of `Open` it shows `Closed` right before the IP Address.

If the `-g` (grepable) option is set, first all open ports are printed for each IPs, then the text **_closed ports:_** is printed and the same output is repeated for all closed ports.


<details>
<summary>Here is an example:</summary>
<br>

```
.----. .-. .-. .----..---.  .----. .---.   .--.  .-. .-.
| {}  }| { } |{ {__ {_   _}{ {__  /  ___} / {} \ |  `| |
| .-. \| {_} |.-._} } | |  .-._} }\     }/  /\  \| |\  |
`-' `-'`-----'`----'  `-'  `----'  `---' `-'  `-'`-' `-'
The Modern Day Port Scanner.
________________________________________
: http://discord.skerritt.blog         :
: https://github.com/RustScan/RustScan :
 --------------------------------------
TreadStone was here 🚀

[~] The config file is expected to be at "/********/.rustscan.toml"
[~] Automatically increasing ulimit value to 50000.
Closed [10.100.0.1]:22
Open [10.100.0.1]:2222
10.100.0.1 -> [2222]
closed ports:
10.100.0.1 -> [22]
```
</details>

<details>
<summary>And with the -g option:</summary>
<br>

```
10.100.0.1 -> [2222]
closed ports:
10.100.0.1 -> [22]
```
</details>