### PR TITLE
fix issue 663: UDP scan returns port as OPEN, when timed-out

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -193,7 +193,10 @@ impl Scanner {
             }
         }
 
-        Ok(socket)
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("UDP scan timed-out for all tries on socket {}", socket),
+        ))
     }
 
     /// Performs the connection to the socket with timeout


### PR DESCRIPTION
This is a fix for #663 (this issue still persists in the latest version).

See my  https://github.com/RustScan/RustScan/issues/663#issuecomment-2611987912 for the explanation.