### PR TITLE
feat(cli): default to XDG_CONFIG_HOME if set

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -320,10 +320,13 @@ impl Config {
 
 /// Constructs default path to config toml
 pub fn default_config_path() -> PathBuf {
-    let Some(mut config_path) = dirs::home_dir() else {
-        panic!("Could not infer config file path.");
+    let config_path = match std::env::var("XDG_CONFIG_HOME") {
+        Ok(path) => PathBuf::from(path).join("rustscan.toml"),
+        Err(_) => dirs::home_dir()
+            .unwrap_or_else(|| panic!("Could not infer config file path."))
+            .join(".rustscan.toml"),
     };
-    config_path.push(".rustscan.toml");
+
     config_path
 }
 


### PR DESCRIPTION
Uses $XDG_CONFIG_HOME/rustscan.toml if it is set, falls back to ~/.rustscan.toml otherwise.