### PR TITLE
feat: preserve IP address order

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -70,18 +70,18 @@ pub fn parse_addresses(input: &Opts) -> Vec<IpAddr> {
     }
 
     // Finally, craft a list of addresses to be excluded from the scan.
-    let mut excluded_ips: Vec<IpAddr> = Vec::new();
+    let mut excluded_ips: BTreeSet<IpAddr> = BTreeSet::new();
     if let Some(exclude_addresses) = &input.exclude_addresses {
         for addr in exclude_addresses {
             excluded_ips.extend(parse_address(addr, &backup_resolver));
         }
     }
 
-    ips.into_iter()
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .filter(|ip| !excluded_ips.contains(ip))
-        .collect()
+    // Remove duplicated/excluded IPs.
+    let mut seen = BTreeSet::new();
+    ips.retain(|ip| seen.insert(*ip) && !excluded_ips.contains(ip));
+
+    ips
 }
 
 /// Given a string, parse it as a host, IP address, or CIDR.


### PR DESCRIPTION
as of #651, IP addresses are deduplicated; as this uses a `BTreeSet`, the original order is not necessarily retained.

- use [`retain()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.retain) to remove duplicated and/or excluded IPs, mutating the original list of IPs but preserving the original order
- modify the excluded IPs list from a `Vec` to a `BTreeSet` to improve performance of those checks