### PR TITLE
fix(config): use canonical XDG path for default config (#741)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -295,11 +295,18 @@ impl Config {
     pub fn read(custom_config_path: Option<PathBuf>) -> Self {
         let mut content = String::new();
         let config_path = custom_config_path.unwrap_or_else(|| {
-            let path = default_config_path();
-            match path.exists() {
-                true => path,
-                false => old_default_config_path(),
+            // Try the XDG-idiomatic location first, then fall back to legacy
+            // paths so existing users keep working unchanged.
+            for path in [
+                default_config_path(),
+                legacy_dot_config_path(),
+                old_default_config_path(),
+            ] {
+                if path.exists() {
+                    return path;
+                }
             }
+            default_config_path()
         });
 
         if config_path.exists() {
@@ -321,8 +328,21 @@ impl Config {
     }
 }
 
-/// Constructs default path to config toml
+/// Returns the preferred config file path: `$XDG_CONFIG_HOME/rustscan/config.toml`
+/// on Linux (with the usual `~/.config` fallback when the variable is unset),
+/// and the platform-equivalent `dirs::config_dir()` location on macOS / Windows.
 pub fn default_config_path() -> PathBuf {
+    let Some(mut config_path) = dirs::config_dir() else {
+        panic!("Could not infer config file path.");
+    };
+    config_path.push("rustscan");
+    config_path.push("config.toml");
+    config_path
+}
+
+/// Returns the transitional `$XDG_CONFIG_HOME/.rustscan.toml` path that older
+/// builds wrote to. Kept readable for backwards compatibility.
+pub fn legacy_dot_config_path() -> PathBuf {
     let Some(mut config_path) = dirs::config_dir() else {
         panic!("Could not infer config file path.");
     };


### PR DESCRIPTION
Closes #741.

## Background

The XDG support originally added to RustScan in 2020 (commit a0561d4 by @mulc) was structured as `$XDG_CONFIG_HOME/rustscan/config.toml`. At some point that was refactored into

```rust
dirs::config_dir().push(".rustscan.toml")
```

which on Linux resolves to `~/.config/.rustscan.toml` — a leading-dot filename inside the already-hidden `.config/` directory. That isn't the form the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) recommends, and it isn't the form mulc's commit introduced.

## Change

Restore the canonical `$XDG_CONFIG_HOME/rustscan/config.toml` path as the primary config location, while preserving full backwards compatibility for both legacy paths.

The loader now searches, in this order:

1. `$XDG_CONFIG_HOME/rustscan/config.toml`  — preferred, XDG-idiomatic
2. `$XDG_CONFIG_HOME/.rustscan.toml`         — transitional, kept for users who already adopted it
3. `~/.rustscan.toml`                         — legacy

Any user who already has a working config file in path 2 or 3 keeps working unchanged.

On macOS this maps to `~/Library/Application Support/rustscan/config.toml`, on Windows to `{FOLDERID_RoamingAppData}/rustscan/config.toml` — both via the existing `dirs::config_dir()` crate. The Linux behavior is what users in the issue thread are asking for; the macOS/Windows behavior was already happening because of `dirs::config_dir()`.

## Verification

```
$ XDG_CONFIG_HOME=/tmp/xdg-test mkdir -p /tmp/xdg-test/rustscan
$ printf 'addresses = ["127.0.0.1"]\nports = [22]\n' > /tmp/xdg-test/rustscan/config.toml
$ XDG_CONFIG_HOME=/tmp/xdg-test rustscan -a 127.0.0.1 -p 22
[~] The config file is expected to be at "/tmp/xdg-test/rustscan/config.toml"
[~] For backwards compatibility, the config file may also be at "/home/<user>/.rustscan.toml"
...
```

`cargo test --lib` passes (50 tests, including the existing config tests).

Diff is `+25 / -5` lines, single file, no public-API change beyond adding the new `legacy_dot_config_path()` helper.
