### PR TITLE
fix: suppress stdout in library mode for silent embedding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_derive",
+ "serde_json",
  "text_placeholder",
  "toml",
  "wait-timeout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ once_cell = "1.21.4"
 parameterized = "2.0.0"
 wait-timeout = "0.2"
 criterion = { version = "0.8", features = ["html_reports"] }
+serde_json = "1.0"
 
 [package.metadata.deb]
 depends = "$auto, nmap"

--- a/examples/default_silent.rs
+++ b/examples/default_silent.rs
@@ -1,0 +1,10 @@
+/// Example that verifies the library is silent by default.
+/// Does NOT call enable_output() — all output macros should produce
+/// nothing on stdout. Built and spawned by the integration test in
+/// tests/stdout_suppression.rs.
+fn main() {
+    // Do NOT call enable_output() — library must be silent by default.
+    rustscan::warning!("DEFAULT_SILENT_WARNING");
+    rustscan::detail!("DEFAULT_SILENT_DETAIL");
+    rustscan::output!("DEFAULT_SILENT_OUTPUT");
+}

--- a/examples/stdout_check.rs
+++ b/examples/stdout_check.rs
@@ -1,6 +1,9 @@
 /// Example that exercises output macros with and without suppress_output().
 /// Built and spawned by the integration test in tests/stdout_suppression.rs.
 fn main() {
+    // Enable output first (it is suppressed by default for library consumers).
+    rustscan::enable_output();
+
     // Before suppression: these markers should appear in stdout.
     rustscan::warning!("PRE_SUPPRESS_WARNING");
     rustscan::detail!("PRE_SUPPRESS_DETAIL");

--- a/examples/stdout_check.rs
+++ b/examples/stdout_check.rs
@@ -1,0 +1,16 @@
+/// Example that exercises output macros with and without suppress_output().
+/// Built and spawned by the integration test in tests/stdout_suppression.rs.
+fn main() {
+    // Before suppression: these markers should appear in stdout.
+    rustscan::warning!("PRE_SUPPRESS_WARNING");
+    rustscan::detail!("PRE_SUPPRESS_DETAIL");
+    rustscan::output!("PRE_SUPPRESS_OUTPUT");
+
+    // Suppress all further library output.
+    rustscan::suppress_output();
+
+    // After suppression: these markers must NOT appear in stdout.
+    rustscan::warning!("POST_SUPPRESS_WARNING");
+    rustscan::detail!("POST_SUPPRESS_DETAIL");
+    rustscan::output!("POST_SUPPRESS_OUTPUT");
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -312,8 +312,10 @@ impl Config {
         let config: Config = match toml::from_str(&content) {
             Ok(config) => config,
             Err(e) => {
-                println!("Found {e} in configuration file.\nAborting scan.\n");
-                std::process::exit(1);
+                if !crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+                    println!("Found {e} in configuration file.\nAborting scan.\n");
+                }
+                panic!("Found {} in configuration file.\nAborting scan.", e);
             }
         };
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -315,7 +315,7 @@ impl Config {
                 if !crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
                     println!("Found {e} in configuration file.\nAborting scan.\n");
                 }
-                panic!("Found {} in configuration file.\nAborting scan.", e);
+                std::process::exit(1);
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,43 @@ pub mod scripts;
 pub mod address;
 
 pub mod generated;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn suppress_output_defaults_to_false() {
+        // Ensure stdout is NOT suppressed by default (CLI mode).
+        // Reset atomics can carry state across tests, so explicitly store false.
+        SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
+        assert!(
+            !SUPPRESS_STDOUT.load(Ordering::Relaxed),
+            "SUPPRESS_STDOUT should default to false so CLI prints normally"
+        );
+    }
+
+    #[test]
+    fn suppress_output_disables_stdout() {
+        // Verify suppress_output() flips the guard to true.
+        SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
+        suppress_output();
+        assert!(
+            SUPPRESS_STDOUT.load(Ordering::Relaxed),
+            "suppress_output() should set SUPPRESS_STDOUT to true"
+        );
+    }
+
+    #[test]
+    fn suppress_output_is_callable_multiple_times() {
+        // Calling suppress_output() repeatedly must remain idempotent.
+        SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
+        suppress_output();
+        suppress_output();
+        assert!(
+            SUPPRESS_STDOUT.load(Ordering::Relaxed),
+            "repeated calls to suppress_output() must leave SUPPRESS_STDOUT true"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,28 @@
 //! ```
 #![allow(clippy::needless_doctest_main)]
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// When `true`, all stdout output from the library is suppressed.
+/// The CLI entry point (`main.rs`) never sets this, so it prints normally.
+/// Library consumers should call [`suppress_output()`] to silence output.
+#[doc(hidden)]
+pub static SUPPRESS_STDOUT: AtomicBool = AtomicBool::new(false);
+
+/// Suppress all stdout output from the library.
+///
+/// Call this once before using the scanner when using RustScan as a library
+/// dependency to prevent noisy terminal output. Has no effect on `log`
+/// crate logging (which is controlled by `RUST_LOG`).
+///
+/// ```ignore
+/// rustscan::suppress_output();
+/// // ... construct and run the scanner normally
+/// ```
+pub fn suppress_output() {
+    SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
+}
+
 pub mod tui;
 
 pub mod input;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,35 +100,30 @@ mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
 
-    /// Unit test: verify the flag mechanism toggles correctly.
-    /// The actual stdout suppression effect is verified by the
-    /// integration test in tests/stdout_suppression.rs.
+    /// Sequential test covering all toggle behaviours on the shared
+    /// `SUPPRESS_STDOUT` static.  Individual `#[test]` functions would
+    /// race under parallel test execution; a single test runs them in
+    /// the order shown and is safe with any `--test-threads` setting.
+    ///
+    /// The actual stdout-suppression effect is verified by the
+    /// integration tests in tests/stdout_suppression.rs, which spawn
+    /// subprocesses and therefore have no shared state.
     #[test]
-    fn suppress_output_sets_flag() {
+    fn toggle_flag_behavior() {
+        // --- suppress_output sets the flag ---
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
         suppress_output();
         assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
-    }
 
-    #[test]
-    fn suppress_output_is_idempotent() {
+        // --- suppress_output is idempotent ---
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
         suppress_output();
         suppress_output();
         assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
-    }
 
-    #[test]
-    fn enable_output_clears_flag() {
+        // --- enable_output clears the flag ---
         SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
         enable_output();
         assert!(!SUPPRESS_STDOUT.load(Ordering::Relaxed));
-    }
-
-    #[test]
-    fn default_is_suppressed() {
-        // Reset to default and verify silent-by-default behavior.
-        SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
-        assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@ mod tests {
     /// subprocesses and therefore have no shared state.
     #[test]
     fn toggle_flag_behavior() {
+        // Save original value to avoid contaminating parallel unit tests
+        // that share the process-global AtomicBool.
+        let original = SUPPRESS_STDOUT.load(Ordering::Relaxed);
+
         // --- suppress_output sets the flag ---
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
         suppress_output();
@@ -125,5 +129,8 @@ mod tests {
         SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
         enable_output();
         assert!(!SUPPRESS_STDOUT.load(Ordering::Relaxed));
+
+        // Restore original value so parallel tests see the expected state.
+        SUPPRESS_STDOUT.store(original, Ordering::Relaxed);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,37 +84,21 @@ mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
 
+    /// Unit test: verify the flag mechanism toggles correctly.
+    /// The actual stdout suppression effect is verified by the
+    /// integration test in tests/stdout_suppression.rs.
     #[test]
-    fn suppress_output_defaults_to_false() {
-        // Ensure stdout is NOT suppressed by default (CLI mode).
-        // Reset atomics can carry state across tests, so explicitly store false.
+    fn suppress_output_sets_flag() {
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
-        assert!(
-            !SUPPRESS_STDOUT.load(Ordering::Relaxed),
-            "SUPPRESS_STDOUT should default to false so CLI prints normally"
-        );
+        suppress_output();
+        assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
     }
 
     #[test]
-    fn suppress_output_disables_stdout() {
-        // Verify suppress_output() flips the guard to true.
-        SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
-        suppress_output();
-        assert!(
-            SUPPRESS_STDOUT.load(Ordering::Relaxed),
-            "suppress_output() should set SUPPRESS_STDOUT to true"
-        );
-    }
-
-    #[test]
-    fn suppress_output_is_callable_multiple_times() {
-        // Calling suppress_output() repeatedly must remain idempotent.
+    fn suppress_output_is_idempotent() {
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
         suppress_output();
         suppress_output();
-        assert!(
-            SUPPRESS_STDOUT.load(Ordering::Relaxed),
-            "repeated calls to suppress_output() must leave SUPPRESS_STDOUT true"
-        );
+        assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,23 +44,39 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// When `true`, all stdout output from the library is suppressed.
-/// The CLI entry point (`main.rs`) never sets this, so it prints normally.
-/// Library consumers should call [`suppress_output()`] to silence output.
+/// Defaults to `true` so that library consumers get silent output.
+/// The CLI entry point (`main.rs`) calls [`enable_output()`] at startup
+/// to restore normal terminal printing.
 #[doc(hidden)]
-pub static SUPPRESS_STDOUT: AtomicBool = AtomicBool::new(false);
+pub static SUPPRESS_STDOUT: AtomicBool = AtomicBool::new(true);
 
 /// Suppress all stdout output from the library.
 ///
-/// Call this once before using the scanner when using RustScan as a library
-/// dependency to prevent noisy terminal output. Has no effect on `log`
-/// crate logging (which is controlled by `RUST_LOG`).
+/// Output is suppressed by default. Call this only after calling
+/// [`enable_output()`] if you need to re-silence output mid-session.
+/// Has no effect on `log` crate logging (controlled by `RUST_LOG`).
 ///
 /// ```ignore
+/// rustscan::enable_output();
+/// // ... print something ...
 /// rustscan::suppress_output();
-/// // ... construct and run the scanner normally
+/// // ... output is silent again
 /// ```
 pub fn suppress_output() {
     SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
+}
+
+/// Enable stdout output from the library.
+///
+/// Output is suppressed by default. The CLI calls this at startup;
+/// library consumers should call this only if they want terminal output.
+///
+/// ```ignore
+/// rustscan::enable_output();
+/// // ... output will now print to stdout
+/// ```
+pub fn enable_output() {
+    SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
 }
 
 pub mod tui;
@@ -99,6 +115,20 @@ mod tests {
         SUPPRESS_STDOUT.store(false, Ordering::Relaxed);
         suppress_output();
         suppress_output();
+        assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn enable_output_clears_flag() {
+        SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
+        enable_output();
+        assert!(!SUPPRESS_STDOUT.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn default_is_suppressed() {
+        // Reset to default and verify silent-by-default behavior.
+        SUPPRESS_STDOUT.store(true, Ordering::Relaxed);
         assert!(SUPPRESS_STDOUT.load(Ordering::Relaxed));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ extern crate log;
 /// Faster Nmap scanning with Rust
 /// If you're looking for the actual scanning, check out the module Scanner
 fn main() {
+    // Enable stdout output for CLI usage (suppressed by default for library consumers).
+    rustscan::enable_output();
+
     #[cfg(not(unix))]
     let _ = ansi_term::enable_ansi_support();
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -289,7 +289,7 @@ impl Scanner {
             }
             Err(e) => {
                 if !crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
-                    eprintln!("Err E binding sock {e:?}");
+                    println!("Err E binding sock {e:?}");
                 }
                 Err(e)
             }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -288,7 +288,9 @@ impl Scanner {
                 }
             }
             Err(e) => {
-                println!("Err E binding sock {e:?}");
+                if !crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+                    eprintln!("Err E binding sock {e:?}");
+                }
                 Err(e)
             }
         }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -298,7 +298,7 @@ impl Scanner {
 
     /// Formats and prints the port status
     fn fmt_ports(&self, socket: SocketAddr) {
-        if !self.greppable {
+        if !crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) && !self.greppable {
             if self.accessible {
                 println!("Open {socket}");
             } else {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,7 +5,9 @@
 #[macro_export]
 macro_rules! warning {
     ($name:expr) => {
-        println!("{} {}", ansi_term::Colour::Red.bold().paint("[!]"), $name);
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+            println!("{} {}", ansi_term::Colour::Red.bold().paint("[!]"), $name);
+        }
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
@@ -23,7 +25,9 @@ macro_rules! warning {
 #[macro_export]
 macro_rules! detail {
     ($name:expr) => {
-        println!("{} {}", ansi_term::Colour::Blue.bold().paint("[~]"), $name);
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+            println!("{} {}", ansi_term::Colour::Blue.bold().paint("[~]"), $name);
+        }
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
@@ -41,11 +45,13 @@ macro_rules! detail {
 #[macro_export]
 macro_rules! output {
     ($name:expr) => {
-        println!(
-            "{} {}",
-            ansi_term::Colour::RGB(0, 255, 9).bold().paint("[>]"),
-            $name
-        );
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+            println!(
+                "{} {}",
+                ansi_term::Colour::RGB(0, 255, 9).bold().paint("[>]"),
+                $name
+            );
+        }
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
@@ -68,39 +74,41 @@ macro_rules! output {
 macro_rules! funny_opening {
     // prints a funny quote / opening
     () => {
-        use rand::seq::IndexedRandom;
-        let quotes = vec![
-            "Nmap? More like slowmap.🐢",
-            "🌍HACK THE PLANET🌍",
-            "Real hackers hack time ⌛",
-            "Please contribute more quotes to our GitHub https://github.com/rustscan/rustscan",
-            "😵 https://admin.tryhackme.com",
-            "0day was here ♥",
-            "I don't always scan ports, but when I do, I prefer RustScan.",
-            "RustScan: Where scanning meets swagging. 😎",
-            "To scan or not to scan? That is the question.",
-            "RustScan: Because guessing isn't hacking.",
-            "Scanning ports like it's my full-time job. Wait, it is.",
-            "Open ports, closed hearts.",
-            "I scanned my computer so many times, it thinks we're dating.",
-            "Port scanning: Making networking exciting since... whenever.",
-            "You miss 100% of the ports you don't scan. - RustScan",
-            "Breaking and entering... into the world of open ports.",
-            "TCP handshake? More like a friendly high-five!",
-            "Scanning ports: The virtual equivalent of knocking on doors.",
-            "RustScan: Making sure 'closed' isn't just a state of mind.",
-            "RustScan: allowing you to send UDP packets into the void 1200x faster than NMAP",
-            "Port scanning: Because every port has a story to tell.",
-            "I scanned ports so fast, even my computer was surprised.",
-            "Scanning ports faster than you can say 'SYN ACK'",
-            "RustScan: Where '404 Not Found' meets '200 OK'.",
-            "RustScan: Exploring the digital landscape, one IP at a time.",
-            "TreadStone was here 🚀",
-            "With RustScan, I scan ports so fast, even my firewall gets whiplash 💨",
-            "Scanning ports so fast, even the internet got a speeding ticket!",
-        ];
-        let random_quote = quotes.choose(&mut rand::rng()).unwrap();
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) {
+            use rand::seq::IndexedRandom;
+            let quotes = vec![
+                "Nmap? More like slowmap.🐢",
+                "🌍HACK THE PLANET🌍",
+                "Real hackers hack time ⌛",
+                "Please contribute more quotes to our GitHub https://github.com/rustscan/rustscan",
+                "😵 https://admin.tryhackme.com",
+                "0day was here ♥",
+                "I don't always scan ports, but when I do, I prefer RustScan.",
+                "RustScan: Where scanning meets swagging. 😎",
+                "To scan or not to scan? That is the question.",
+                "RustScan: Because guessing isn't hacking.",
+                "Scanning ports like it's my full-time job. Wait, it is.",
+                "Open ports, closed hearts.",
+                "I scanned my computer so many times, it thinks we're dating.",
+                "Port scanning: Making networking exciting since... whenever.",
+                "You miss 100% of the ports you don't scan. - RustScan",
+                "Breaking and entering... into the world of open ports.",
+                "TCP handshake? More like a friendly high-five!",
+                "Scanning ports: The virtual equivalent of knocking on doors.",
+                "RustScan: Making sure 'closed' isn't just a state of mind.",
+                "RustScan: allowing you to send UDP packets into the void 1200x faster than NMAP",
+                "Port scanning: Because every port has a story to tell.",
+                "I scanned ports so fast, even my computer was surprised.",
+                "Scanning ports faster than you can say 'SYN ACK'",
+                "RustScan: Where '404 Not Found' meets '200 OK'.",
+                "RustScan: Exploring the digital landscape, one IP at a time.",
+                "TreadStone was here 🚀",
+                "With RustScan, I scan ports so fast, even my firewall gets whiplash 💨",
+                "Scanning ports so fast, even the internet got a speeding ticket!",
+            ];
+            let random_quote = quotes.choose(&mut rand::rng()).unwrap();
 
-        println!("{}\n", random_quote);
+            println!("{}\n", random_quote);
+        }
     };
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,7 @@ macro_rules! warning {
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
-        if !$greppable {
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) && !$greppable {
             if $accessible {
                 // Don't print the ascii art
                 println!("{}", $name);
@@ -31,7 +31,7 @@ macro_rules! detail {
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
-        if !$greppable {
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) && !$greppable {
             if $accessible {
                 // Don't print the ascii art
                 println!("{}", $name);
@@ -55,7 +55,7 @@ macro_rules! output {
     };
     ($name:expr, $greppable:expr, $accessible:expr) => {
         // if not greppable then print, otherwise no else statement so do not print.
-        if !$greppable {
+        if !$crate::SUPPRESS_STDOUT.load(std::sync::atomic::Ordering::Relaxed) && !$greppable {
             if $accessible {
                 // Don't print the ascii art
                 println!("{}", $name);

--- a/tests/stdout_suppression.rs
+++ b/tests/stdout_suppression.rs
@@ -1,0 +1,104 @@
+//! Integration test: verify that suppress_output() actually silences
+//! stdout produced by the library's output macros (`warning!`, `detail!`,
+//! `output!`).  The test builds and runs the `stdout_check` example as a
+//! subprocess so we can capture real stdout rather than just checking the
+//! internal AtomicBool flag.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Locate the compiled `stdout_check` example binary.
+fn example_binary() -> PathBuf {
+    // Cargo sets CARGO_BIN_EXE_<name> for bin targets; examples may
+    // also be available under this key depending on the Cargo version.
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_stdout_check") {
+        let path = PathBuf::from(p);
+        if path.exists() {
+            return path;
+        }
+    }
+
+    let manifest =
+        std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").into());
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    PathBuf::from(manifest)
+        .join("target")
+        .join(profile)
+        .join("examples")
+        .join("stdout_check")
+}
+
+/// Build the example if it hasn't been built yet.
+fn ensure_example_built() {
+    let status = Command::new("cargo")
+        .args(["build", "--example", "stdout_check"])
+        .status()
+        .expect("failed to run cargo build --example stdout_check");
+    assert!(
+        status.success(),
+        "cargo build --example stdout_check failed"
+    );
+}
+
+#[test]
+fn suppress_output_actually_silences_macro_output() {
+    ensure_example_built();
+
+    let bin = example_binary();
+    assert!(
+        bin.exists(),
+        "example binary not found at {}; run `cargo build --example stdout_check`",
+        bin.display()
+    );
+
+    let output = Command::new(&bin)
+        .output()
+        .expect("failed to spawn stdout_check example");
+
+    assert!(
+        output.status.success(),
+        "example exited with {}: stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Pre-suppression markers must be present.
+    assert!(
+        stdout.contains("PRE_SUPPRESS_WARNING"),
+        "PRE_SUPPRESS_WARNING missing from stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("PRE_SUPPRESS_DETAIL"),
+        "PRE_SUPPRESS_DETAIL missing from stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("PRE_SUPPRESS_OUTPUT"),
+        "PRE_SUPPRESS_OUTPUT missing from stdout:\n{}",
+        stdout
+    );
+
+    // Post-suppression markers must be absent.
+    assert!(
+        !stdout.contains("POST_SUPPRESS_WARNING"),
+        "POST_SUPPRESS_WARNING leaked into stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("POST_SUPPRESS_DETAIL"),
+        "POST_SUPPRESS_DETAIL leaked into stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("POST_SUPPRESS_OUTPUT"),
+        "POST_SUPPRESS_OUTPUT leaked into stdout:\n{}",
+        stdout
+    );
+}

--- a/tests/stdout_suppression.rs
+++ b/tests/stdout_suppression.rs
@@ -7,11 +7,10 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Locate the compiled `stdout_check` example binary.
-fn example_binary() -> PathBuf {
-    // Cargo sets CARGO_BIN_EXE_<name> for bin targets; examples may
-    // also be available under this key depending on the Cargo version.
-    if let Ok(p) = std::env::var("CARGO_BIN_EXE_stdout_check") {
+/// Locate a compiled example binary by name.
+fn example_binary(name: &str) -> PathBuf {
+    let env_key = format!("CARGO_BIN_EXE_{name}");
+    if let Ok(p) = std::env::var(&env_key) {
         let path = PathBuf::from(p);
         if path.exists() {
             return path;
@@ -29,26 +28,23 @@ fn example_binary() -> PathBuf {
         .join("target")
         .join(profile)
         .join("examples")
-        .join("stdout_check")
+        .join(name)
 }
 
-/// Build the example if it hasn't been built yet.
-fn ensure_example_built() {
+/// Build an example by name if it hasn't been built yet.
+fn ensure_example_built(name: &str) {
     let status = Command::new("cargo")
-        .args(["build", "--example", "stdout_check"])
+        .args(["build", "--example", name])
         .status()
-        .expect("failed to run cargo build --example stdout_check");
-    assert!(
-        status.success(),
-        "cargo build --example stdout_check failed"
-    );
+        .expect("failed to run cargo build");
+    assert!(status.success(), "cargo build --example {} failed", name);
 }
 
 #[test]
 fn suppress_output_actually_silences_macro_output() {
-    ensure_example_built();
+    ensure_example_built("stdout_check");
 
-    let bin = example_binary();
+    let bin = example_binary("stdout_check");
     assert!(
         bin.exists(),
         "example binary not found at {}; run `cargo build --example stdout_check`",
@@ -99,6 +95,51 @@ fn suppress_output_actually_silences_macro_output() {
     assert!(
         !stdout.contains("POST_SUPPRESS_OUTPUT"),
         "POST_SUPPRESS_OUTPUT leaked into stdout:\n{}",
+        stdout
+    );
+}
+
+/// Fresh-process test: verify the library is silent by default.
+/// The `default_silent` example does NOT call `enable_output()`,
+/// so all macro output should be suppressed by the initialiser.
+#[test]
+fn default_silent_output_is_suppressed() {
+    ensure_example_built("default_silent");
+
+    let bin = example_binary("default_silent");
+    assert!(
+        bin.exists(),
+        "example binary not found at {}; run `cargo build --example default_silent`",
+        bin.display()
+    );
+
+    let output = Command::new(&bin)
+        .output()
+        .expect("failed to spawn default_silent example");
+
+    assert!(
+        output.status.success(),
+        "example exited with {}: stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Default-silent markers must NOT appear — library is silent by default.
+    assert!(
+        !stdout.contains("DEFAULT_SILENT_WARNING"),
+        "DEFAULT_SILENT_WARNING leaked into stdout (library should be silent by default):\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("DEFAULT_SILENT_DETAIL"),
+        "DEFAULT_SILENT_DETAIL leaked into stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("DEFAULT_SILENT_OUTPUT"),
+        "DEFAULT_SILENT_OUTPUT leaked into stdout:\n{}",
         stdout
     );
 }

--- a/tests/stdout_suppression.rs
+++ b/tests/stdout_suppression.rs
@@ -28,7 +28,7 @@ fn example_binary(name: &str) -> PathBuf {
         .join("target")
         .join(profile)
         .join("examples")
-        .join(name)
+        .join(format!("{}{}", name, std::env::consts::EXE_SUFFIX))
 }
 
 /// Build an example by name if it hasn't been built yet.

--- a/tests/stdout_suppression.rs
+++ b/tests/stdout_suppression.rs
@@ -7,49 +7,58 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Locate a compiled example binary by name.
-fn example_binary(name: &str) -> PathBuf {
-    let env_key = format!("CARGO_BIN_EXE_{name}");
-    if let Ok(p) = std::env::var(&env_key) {
-        let path = PathBuf::from(p);
-        if path.exists() {
-            return path;
+/// Build an example and return the path to the compiled binary.
+///
+/// Uses `cargo build --message-format=json` so that the profile matches
+/// the test binary (`cfg!(debug_assertions)`) and the returned path
+/// respects `CARGO_TARGET_DIR` and workspace layouts.
+fn build_example(name: &str) -> PathBuf {
+    let mut args: Vec<&str> = vec!["build", "--example", name, "--message-format=json"];
+    if !cfg!(debug_assertions) {
+        args.push("--release");
+    }
+
+    let output = Command::new("cargo")
+        .args(&args)
+        .output()
+        .expect("failed to run cargo build");
+
+    assert!(
+        output.status.success(),
+        "cargo build --example {} failed\nstderr:\n{}",
+        name,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.contains("\"reason\":\"compiler-artifact\"")
+            && line.contains(&format!("\"name\":\"{}\"", name))
+        {
+            if let Some(start) = line.find("\"executable\":\"") {
+                let start = start + "\"executable\":\"".len();
+                if let Some(end) = line[start..].find('"') {
+                    let path = PathBuf::from(&line[start..start + end]);
+                    assert!(
+                        path.exists(),
+                        "cargo-reported binary does not exist: {}",
+                        path.display()
+                    );
+                    return path;
+                }
+            }
         }
     }
 
-    let manifest =
-        std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").into());
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    PathBuf::from(manifest)
-        .join("target")
-        .join(profile)
-        .join("examples")
-        .join(format!("{}{}", name, std::env::consts::EXE_SUFFIX))
-}
-
-/// Build an example by name if it hasn't been built yet.
-fn ensure_example_built(name: &str) {
-    let status = Command::new("cargo")
-        .args(["build", "--example", name])
-        .status()
-        .expect("failed to run cargo build");
-    assert!(status.success(), "cargo build --example {} failed", name);
+    panic!(
+        "could not find executable for example '{}' in cargo build output",
+        name
+    );
 }
 
 #[test]
 fn suppress_output_actually_silences_macro_output() {
-    ensure_example_built("stdout_check");
-
-    let bin = example_binary("stdout_check");
-    assert!(
-        bin.exists(),
-        "example binary not found at {}; run `cargo build --example stdout_check`",
-        bin.display()
-    );
+    let bin = build_example("stdout_check");
 
     let output = Command::new(&bin)
         .output()
@@ -104,14 +113,7 @@ fn suppress_output_actually_silences_macro_output() {
 /// so all macro output should be suppressed by the initialiser.
 #[test]
 fn default_silent_output_is_suppressed() {
-    ensure_example_built("default_silent");
-
-    let bin = example_binary("default_silent");
-    assert!(
-        bin.exists(),
-        "example binary not found at {}; run `cargo build --example default_silent`",
-        bin.display()
-    );
+    let bin = build_example("default_silent");
 
     let output = Command::new(&bin)
         .output()

--- a/tests/stdout_suppression.rs
+++ b/tests/stdout_suppression.rs
@@ -32,21 +32,32 @@ fn build_example(name: &str) -> PathBuf {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
-        if line.contains("\"reason\":\"compiler-artifact\"")
-            && line.contains(&format!("\"name\":\"{}\"", name))
+        let value: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        if value.get("reason").and_then(|v| v.as_str()) != Some("compiler-artifact") {
+            continue;
+        }
+
+        if value
+            .get("target")
+            .and_then(|v| v.get("name"))
+            .and_then(|v| v.as_str())
+            != Some(name)
         {
-            if let Some(start) = line.find("\"executable\":\"") {
-                let start = start + "\"executable\":\"".len();
-                if let Some(end) = line[start..].find('"') {
-                    let path = PathBuf::from(&line[start..start + end]);
-                    assert!(
-                        path.exists(),
-                        "cargo-reported binary does not exist: {}",
-                        path.display()
-                    );
-                    return path;
-                }
-            }
+            continue;
+        }
+
+        if let Some(executable) = value.get("executable").and_then(|v| v.as_str()) {
+            let path = PathBuf::from(executable);
+            assert!(
+                path.exists(),
+                "cargo-reported binary does not exist: {}",
+                path.display()
+            );
+            return path;
         }
     }
 


### PR DESCRIPTION
Default library output to silent. CLI explicitly enables output. Tests verify fresh-process default-silent behavior, toggle flag isolation, and cross-platform binary path resolution.

Fixes: #706

Signed-off-by: Functionhx <2994114386@qq.com>